### PR TITLE
Fix for updated ego token structure

### DIFF
--- a/src/main/java/org/icgc/argo/program_service/services/ego/Context.java
+++ b/src/main/java/org/icgc/argo/program_service/services/ego/Context.java
@@ -9,6 +9,7 @@ import lombok.Setter;
 public class Context {
 
   User user;
+  String[] scope;
 
   @JsonIgnoreProperties(ignoreUnknown = true)
   @Setter @Getter

--- a/src/main/java/org/icgc/argo/program_service/services/ego/model/entity/EgoToken.java
+++ b/src/main/java/org/icgc/argo/program_service/services/ego/model/entity/EgoToken.java
@@ -6,11 +6,13 @@ import org.springframework.beans.BeanUtils;
 
 import javax.validation.constraints.NotNull;
 
+// FIXME: This needs to be refactored because an Ego Token is more than a user
 public class EgoToken extends Context.User {
   final DecodedJWT jwt;
 
   public EgoToken(@NotNull DecodedJWT jwt, @NotNull Context context) {
     this.jwt = jwt;
     BeanUtils.copyProperties(context.getUser(), this);
+    this.setPermissions(context.getScope());
   }
 }

--- a/src/test/java/org/icgc/argo/program_service/grpc/ProgramServiceAuthorizationTest.java
+++ b/src/test/java/org/icgc/argo/program_service/grpc/ProgramServiceAuthorizationTest.java
@@ -520,9 +520,9 @@ class Signer {
     val context = new Context();
     val u = getUser(isEgoAdmin);
     u.setCreatedAt(issued.toString());
-    u.setPermissions(permissions);
     u.setEmail(email);
     context.setUser(u);
+    context.setScope(permissions);
 
     return Jwts.builder()
       .setIssuedAt(issued)


### PR DESCRIPTION
This is a quick fix that allows the program service to use the updated Ego JWT. 

Unit tests have been updated to reflect change.

A refactor should still take place in the future as the semantics of 
```java 
public class EgoToken extends Context.User
```
 are wrong. It should extend the Context or even more as the token could be making use of the aud field. 