### PR TITLE
Remove coupling of EgoSecurity and grpc

### DIFF
--- a/src/main/java/org/icgc/argo/program_service/grpc/interceptor/EgoAuthInterceptor.java
+++ b/src/main/java/org/icgc/argo/program_service/grpc/interceptor/EgoAuthInterceptor.java
@@ -20,13 +20,12 @@ package org.icgc.argo.program_service.grpc.interceptor;
 
 import io.grpc.*;
 import lombok.NonNull;
+import lombok.val;
 import org.icgc.argo.program_service.security.EgoSecurity;
 import org.icgc.argo.program_service.services.ego.model.entity.EgoToken;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
-
-import java.util.Optional;
 
 import static io.grpc.Metadata.ASCII_STRING_MARSHALLER;
 
@@ -51,7 +50,7 @@ public class EgoAuthInterceptor implements AuthInterceptor {
     Metadata metadata,
     ServerCallHandler<ReqT, RespT> next) {
     String token = metadata.get(JWT_METADATA_KEY);
-    Optional<EgoToken> egoToken = egoSecurity.verifyToken(token);
+    val egoToken = egoSecurity.verifyToken(token);
     Context context = Context.current().withValue(EGO_TOKEN, egoToken.orElse(null));
     return Contexts.interceptCall(context, call, metadata, next);
   }

--- a/src/main/java/org/icgc/argo/program_service/grpc/interceptor/EgoAuthInterceptor.java
+++ b/src/main/java/org/icgc/argo/program_service/grpc/interceptor/EgoAuthInterceptor.java
@@ -20,12 +20,13 @@ package org.icgc.argo.program_service.grpc.interceptor;
 
 import io.grpc.*;
 import lombok.NonNull;
-import lombok.val;
 import org.icgc.argo.program_service.security.EgoSecurity;
 import org.icgc.argo.program_service.services.ego.model.entity.EgoToken;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
+
+import java.util.Optional;
 
 import static io.grpc.Metadata.ASCII_STRING_MARSHALLER;
 
@@ -50,7 +51,7 @@ public class EgoAuthInterceptor implements AuthInterceptor {
     Metadata metadata,
     ServerCallHandler<ReqT, RespT> next) {
     String token = metadata.get(JWT_METADATA_KEY);
-    val egoToken = egoSecurity.verifyToken(token);
+    Optional<EgoToken> egoToken = egoSecurity.verifyToken(token);
     Context context = Context.current().withValue(EGO_TOKEN, egoToken.orElse(null));
     return Contexts.interceptCall(context, call, metadata, next);
   }

--- a/src/main/java/org/icgc/argo/program_service/security/EgoSecurity.java
+++ b/src/main/java/org/icgc/argo/program_service/security/EgoSecurity.java
@@ -6,7 +6,6 @@ import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.JWTDecodeException;
 import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
-import io.grpc.Status;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -41,10 +40,9 @@ public class EgoSecurity {
               .build(); //Reusable verifier instance
       val jwt = verifier.verify(jwtToken);
       return parseToken(jwt);
-    } catch (JWTVerificationException e) {
-      throw Status.PERMISSION_DENIED.asRuntimeException();
-    } catch (NullPointerException e) {
-      throw Status.UNAUTHENTICATED.asRuntimeException();
+    } catch (JWTVerificationException | NullPointerException e) {
+      // ego security shouldn't have knowledge of grpc
+      return Optional.empty();
     }
   }
 

--- a/src/main/java/org/icgc/argo/program_service/security/EgoSecurity.java
+++ b/src/main/java/org/icgc/argo/program_service/security/EgoSecurity.java
@@ -41,6 +41,7 @@ public class EgoSecurity {
       val jwt = verifier.verify(jwtToken);
       return parseToken(jwt);
     } catch (JWTVerificationException | NullPointerException e) {
+      log.warn(e.getMessage());
       // ego security shouldn't have knowledge of grpc
       return Optional.empty();
     }

--- a/src/test/java/org/icgc/argo/program_service/grpc/ProgramServiceAuthorizationTest.java
+++ b/src/test/java/org/icgc/argo/program_service/grpc/ProgramServiceAuthorizationTest.java
@@ -21,11 +21,7 @@ import org.icgc.argo.program_service.model.entity.JoinProgramInviteEntity;
 import org.icgc.argo.program_service.model.entity.ProgramEntity;
 import org.icgc.argo.program_service.model.join.ProgramCountry;
 import org.icgc.argo.program_service.proto.*;
-
-import org.icgc.argo.program_service.repositories.JoinProgramInviteRepository;
-
 import org.icgc.argo.program_service.security.EgoSecurity;
-
 import org.icgc.argo.program_service.services.EgoAuthorizationService;
 import org.icgc.argo.program_service.services.InvitationService;
 import org.icgc.argo.program_service.services.ProgramService;
@@ -34,6 +30,7 @@ import org.icgc.argo.program_service.services.ego.Context;
 import org.icgc.argo.program_service.services.ego.EgoService;
 import org.junit.Rule;
 import org.junit.jupiter.api.Test;
+
 import java.io.IOException;
 import java.security.Key;
 import java.security.interfaces.RSAPublicKey;
@@ -184,7 +181,7 @@ public class ProgramServiceAuthorizationTest {
 
     val tests = runTests("ExpiredToken", client);
     closeChannel(c.getChannel());
-    assert tests.threwStatusException(Status.PERMISSION_DENIED);
+    assert tests.threwStatusException(Status.UNAUTHENTICATED);
   }
 
   @Test
@@ -195,7 +192,7 @@ public class ProgramServiceAuthorizationTest {
 
     val tests = runTests("InvalidToken", client);
     closeChannel(c.getChannel());
-    assert tests.threwStatusException(Status.PERMISSION_DENIED);
+    assert tests.threwStatusException(Status.UNAUTHENTICATED);
   }
 
   @Test
@@ -205,7 +202,7 @@ public class ProgramServiceAuthorizationTest {
     val tests = runTests("WrongKey", addAuthHeader(c, tokenWrongKey()));
     closeChannel(c.getChannel());
 
-    assert tests.threwStatusException(Status.PERMISSION_DENIED);
+    assert tests.threwStatusException(Status.UNAUTHENTICATED);
   }
 
   @Test
@@ -246,7 +243,8 @@ public class ProgramServiceAuthorizationTest {
     val client = addAuthHeader(c, tokenDCCAdminWrongKey());
 
     val tests = runTests("DCCAdminWrongKey", client);
-    assert tests.threwStatusException(Status.PERMISSION_DENIED);
+    // Wrong key cannot be authenticated
+    assert tests.threwStatusException(Status.UNAUTHENTICATED);
     closeChannel(c.getChannel());
   }
 


### PR DESCRIPTION
It's not good to let EgoSecurity to raise a grpc runtime exception directly. 