### PR TITLE
Service facade to fix transactions and service encapsulation

### DIFF
--- a/src/main/java/org/icgc/argo/program_service/grpc/ProgramServiceImpl.java
+++ b/src/main/java/org/icgc/argo/program_service/grpc/ProgramServiceImpl.java
@@ -30,139 +30,73 @@ import org.icgc.argo.program_service.converter.ProgramConverter;
 import org.icgc.argo.program_service.model.entity.ProgramEntity;
 import org.icgc.argo.program_service.model.exceptions.NotFoundException;
 import org.icgc.argo.program_service.proto.*;
-import org.icgc.argo.program_service.services.AuthorizationService;
-import org.icgc.argo.program_service.services.InvitationService;
-import org.icgc.argo.program_service.services.ProgramService;
-import org.icgc.argo.program_service.services.ValidationService;
-import org.icgc.argo.program_service.services.ego.EgoService;
+import org.icgc.argo.program_service.services.ProgramServiceFacade;
+import org.icgc.argo.program_service.services.auth.AuthorizationService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.NestedRuntimeException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.grpc.Status.NOT_FOUND;
 import static io.grpc.Status.UNKNOWN;
-import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
-import static org.icgc.argo.program_service.utils.CollectionUtils.*;
 
 @Slf4j
 @Component
 public class ProgramServiceImpl extends ProgramServiceGrpc.ProgramServiceImplBase {
 
-  /**
-   * Dependencies
-   */
-  private final ProgramService programService;
-  private final InvitationService invitationService;
+  /** Dependencies */
   private final ProgramConverter programConverter;
   private final CommonConverter commonConverter;
-  private final EgoService egoService;
   private final AuthorizationService authorizationService;
-  private final ValidationService validationService;
+  private final ProgramServiceFacade serviceFacade;
 
   @Autowired
-  public ProgramServiceImpl(@NonNull ProgramService programService, @NonNull ProgramConverter programConverter,
-    @NonNull CommonConverter commonConverter, @NonNull EgoService egoService, InvitationService invitationService,
-    AuthorizationService authorizationService,
-    ValidationService validationService) {
-    this.programService = programService;
+  public ProgramServiceImpl(
+      @NonNull ProgramConverter programConverter,
+      @NonNull CommonConverter commonConverter,
+      AuthorizationService authorizationService,
+      ProgramServiceFacade serviceFacade) {
     this.programConverter = programConverter;
-    this.egoService = egoService;
     this.commonConverter = commonConverter;
-    this.invitationService = invitationService;
     this.authorizationService = authorizationService;
-    this.validationService = validationService;
+    this.serviceFacade = serviceFacade;
   }
 
   @Override
-  @Transactional
-  public void createProgram(CreateProgramRequest request, StreamObserver<CreateProgramResponse> responseObserver) {
+  public void createProgram(
+      CreateProgramRequest request, StreamObserver<CreateProgramResponse> responseObserver) {
     authorizationService.requireDCCAdmin();
-
-    val errors = validationService.validateCreateProgramRequest(request);
-    if (errors.size() != 0) {
-      throw Status.INVALID_ARGUMENT.augmentDescription(
-        format("Cannot create program: Program errors are [%s]", join(errors, ","))
-      ).asRuntimeException();
-    }
-    val program = request.getProgram();
-    val admins = request.getAdminsList();
-    val programEntity = programService.createWithSideEffectTransactional(program, (ProgramEntity pe) -> {
-      egoService.setUpProgram(pe.getShortName());
-      admins.forEach(admin -> {
-        val email = commonConverter.unboxStringValue(admin.getEmail());
-        val firstName = commonConverter.unboxStringValue(admin.getFirstName());
-        val lastName = commonConverter.unboxStringValue(admin.getLastName());
-        egoService.getOrCreateUser(email, firstName, lastName);
-        invitationService.inviteUser(pe, email, firstName, lastName, UserRole.ADMIN);
-      });
-    });
-
+    val programEntity = serviceFacade.createProgram(request);
     val response = programConverter.programEntityToCreateProgramResponse(programEntity);
     responseObserver.onNext(response);
     responseObserver.onCompleted();
   }
 
-  private String formatErrors(List<String> errors) {
-    return errors.stream().sorted().collect(Collectors.joining(", "));
-  }
-
   @Override
-  @Transactional
-  public void getProgram(GetProgramRequest request, StreamObserver<GetProgramResponse> responseObserver) {
-    val shortName = request.getShortName().getValue();
-    authorizationService.requireProgramUser(shortName);
-
-    val programEntity = programService.getProgram(shortName);
+  public void getProgram(
+      GetProgramRequest request, StreamObserver<GetProgramResponse> responseObserver) {
+    authorizationService.requireProgramUser(request.getShortName().getValue());
+    val programEntity = serviceFacade.getProgram(request);
     val programDetails = programConverter.ProgramEntityToProgramDetails(programEntity);
     val response = GetProgramResponse.newBuilder().setProgram(programDetails).build();
     responseObserver.onNext(response);
     responseObserver.onCompleted();
   }
 
-  private StatusRuntimeException status(Status code, String message) {
-    return code.
-      augmentDescription(message).
-      asRuntimeException();
-  }
-
-  private StatusRuntimeException status(Throwable throwable) {
-    if (throwable instanceof StatusRuntimeException) {
-      return (StatusRuntimeException) throwable;
-    }
-
-    return Status.UNKNOWN.
-      withCause(throwable).
-      augmentDescription(throwable.getMessage()).
-      asRuntimeException();
-  }
-
   @Override
-  public void updateProgram(UpdateProgramRequest request, StreamObserver<UpdateProgramResponse> responseObserver) {
+  public void updateProgram(
+      UpdateProgramRequest request, StreamObserver<UpdateProgramResponse> responseObserver) {
     authorizationService.requireDCCAdmin();
-
-    val program = request.getProgram();
-    val updatingProgram = programConverter.programToProgramEntity(program);
     try {
-      val updatedProgram = programService.updateProgram(
-        updatingProgram,
-        program.getCancerTypesList(),
-        program.getPrimarySitesList(),
-        program.getInstitutionsList(),
-        program.getCountriesList(),
-        program.getRegionsList()
-      );
+      val updatedProgram = serviceFacade.updateProgram(request);
       val response = programConverter.programEntityToUpdateProgramResponse(updatedProgram);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
@@ -173,46 +107,27 @@ public class ProgramServiceImpl extends ProgramServiceGrpc.ProgramServiceImplBas
   }
 
   @Override
-  @Transactional
-  public void inviteUser(InviteUserRequest request, StreamObserver<InviteUserResponse> responseObserver) {
-    val programShortName = request.getProgramShortName().getValue();
-    authorizationService.requireProgramAdmin(programShortName);
-
-    val programResult = programService.getProgram(programShortName);
-    UUID inviteId;
+  public void inviteUser(
+      InviteUserRequest request, StreamObserver<InviteUserResponse> responseObserver) {
+    authorizationService.requireProgramAdmin(request.getProgramShortName().getValue());
 
     try {
-      val email = commonConverter.unboxStringValue(request.getEmail());
-      val firstName = commonConverter.unboxStringValue(request.getFirstName());
-      val lastName = commonConverter.unboxStringValue(request.getLastName());
-      inviteId = invitationService.inviteUser(programResult, email, firstName, lastName, request.getRole().getValue());
-      egoService.getOrCreateUser(email, firstName, lastName);
+      val inviteId = serviceFacade.inviteUser(request);
+      val inviteUserResponse = programConverter.inviteIdToInviteUserResponse(inviteId);
+      responseObserver.onNext(inviteUserResponse);
+      responseObserver.onCompleted();
     } catch (Throwable throwable) {
       responseObserver.onError(status(throwable));
-      return;
     }
-
-    val inviteUserResponse = programConverter.inviteIdToInviteUserResponse(inviteId);
-
-    responseObserver.onNext(inviteUserResponse);
-    responseObserver.onCompleted();
   }
 
   @Override
-  public void joinProgram(JoinProgramRequest request, StreamObserver<JoinProgramResponse> responseObserver) {
-    val str = request.getJoinProgramInvitationId().getValue();
-    val id = commonConverter.stringToUUID(str);
-
-    val invitation = invitationService.getInvitationById(id);
-
-    if (invitation.isEmpty()) {
-      throw NOT_FOUND.asRuntimeException();
-    }
-
-    authorizationService.requireEmail(invitation.get().getUserEmail());
-
+  public void joinProgram(
+      JoinProgramRequest request, StreamObserver<JoinProgramResponse> responseObserver) {
     try {
-      val responseUser = invitationService.acceptInvite(id);
+      val responseUser =
+          serviceFacade.joinProgram(
+              request, (i) -> authorizationService.requireEmail(i.getUserEmail()));
       val response = programConverter.egoUserToJoinProgramResponse(responseUser);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
@@ -224,42 +139,35 @@ public class ProgramServiceImpl extends ProgramServiceGrpc.ProgramServiceImplBas
 
   @Override
   public void listPrograms(Empty request, StreamObserver<ListProgramsResponse> responseObserver) {
-    List<ProgramEntity> programEntities = programService.listPrograms()
-      .stream()
-      .filter(p -> authorizationService.canRead(p.getShortName()))
-      .collect(toList());
-    val listProgramsResponse = programConverter.programEntitiesToListProgramsResponse(programEntities);
+    List<ProgramEntity> programEntities =
+        serviceFacade.listPrograms().stream()
+            .filter(p -> authorizationService.canRead(p.getShortName()))
+            .collect(toList());
+    val listProgramsResponse =
+        programConverter.programEntitiesToListProgramsResponse(programEntities);
     responseObserver.onNext(listProgramsResponse);
     responseObserver.onCompleted();
   }
 
   @Override
-  public void listUsers(ListUsersRequest request, StreamObserver<ListUsersResponse> responseObserver) {
-    ListUsersResponse response;
+  public void listUsers(
+      ListUsersRequest request, StreamObserver<ListUsersResponse> responseObserver) {
     val programShortName = request.getProgramShortName().getValue();
     authorizationService.requireProgramAdmin(programShortName);
 
-    val users = egoService.getUsersInProgram(programShortName);
-    Set<UserDetails> userDetails = mapToSet(users,
-      user -> programConverter.userWithOptionalJoinProgramInviteToUserDetails(user,
-        invitationService.getLatestInvitation(programShortName, user.getEmail().getValue())));
-
-    userDetails.addAll(mapToList(invitationService.listPendingInvitations(programShortName),
-      programConverter::joinProgramInviteToUserDetails));
-
-    response = ListUsersResponse.newBuilder().addAllUserDetails(userDetails).build();
+    val userDetails = serviceFacade.listUsers(programShortName);
+    val response = ListUsersResponse.newBuilder().addAllUserDetails(userDetails).build();
     responseObserver.onNext(response);
     responseObserver.onCompleted();
   }
 
   @Override
-  public void removeUser(RemoveUserRequest request, StreamObserver<RemoveUserResponse> responseObserver) {
+  public void removeUser(
+      RemoveUserRequest request, StreamObserver<RemoveUserResponse> responseObserver) {
     val programName = request.getProgramShortName().getValue();
     authorizationService.requireProgramAdmin(programName);
 
-    val email = request.getUserEmail().getValue();
-    invitationService.revoke(programName, email);
-    egoService.leaveProgram(email, programName);
+    serviceFacade.removeUser(request);
     val response = programConverter.toRemoveUserResponse("User is successfully removed!");
     responseObserver.onNext(response);
     responseObserver.onCompleted();
@@ -267,14 +175,10 @@ public class ProgramServiceImpl extends ProgramServiceGrpc.ProgramServiceImplBas
 
   @Override
   public void updateUser(UpdateUserRequest request, StreamObserver<Empty> responseObserver) {
-    val programShortName = request.getShortName().getValue();
-    authorizationService.requireProgramAdmin(programShortName);
-
-    val email = request.getUserEmail().getValue();
-    val role = request.getRole().getValue();
+    authorizationService.requireProgramAdmin(request.getShortName().getValue());
 
     try {
-      egoService.updateUserRole(email, programShortName, role);
+      serviceFacade.updateUser(request);
     } catch (NotFoundException e) {
       log.error("Exception throw in updateUser: {}", e.getMessage());
       throw status(NOT_FOUND, e.getMessage());
@@ -284,14 +188,11 @@ public class ProgramServiceImpl extends ProgramServiceGrpc.ProgramServiceImplBas
   }
 
   @Override
-  @Transactional
   public void removeProgram(RemoveProgramRequest request, StreamObserver<Empty> responseObserver) {
     authorizationService.requireDCCAdmin();
 
-    val shortName = request.getProgramShortName().getValue();
     try {
-      egoService.cleanUpProgram(shortName);
-      programService.removeProgram(request.getProgramShortName().getValue());
+      serviceFacade.removeProgram(request);
     } catch (EmptyResultDataAccessException | InvalidDataAccessApiUsageException e) {
       log.error("Exception throw in removeProgram: {}", e.getMessage());
       throw status(NOT_FOUND, getExceptionMessage(e));
@@ -302,23 +203,25 @@ public class ProgramServiceImpl extends ProgramServiceGrpc.ProgramServiceImplBas
 
   @Override
   public void listCancers(Empty request, StreamObserver<ListCancersResponse> responseObserver) {
-    val cancers = programService.listCancers();
+    val cancers = serviceFacade.listCancers();
     val listCancersResponse = programConverter.cancerEntitiesToListCancersResponse(cancers);
     responseObserver.onNext(listCancersResponse);
     responseObserver.onCompleted();
   }
 
   @Override
-  public void listPrimarySites(Empty request, StreamObserver<ListPrimarySitesResponse> responseObserver) {
-    val sites = programService.listPrimarySites();
-    val listPrimarySitesResponse = programConverter.primarySiteEntitiesToListPrimarySitesResponse(sites);
+  public void listPrimarySites(
+      Empty request, StreamObserver<ListPrimarySitesResponse> responseObserver) {
+    val sites = serviceFacade.listPrimarySites();
+    val listPrimarySitesResponse =
+        programConverter.primarySiteEntitiesToListPrimarySitesResponse(sites);
     responseObserver.onNext(listPrimarySitesResponse);
     responseObserver.onCompleted();
   }
 
   @Override
   public void listCountries(Empty request, StreamObserver<ListCountriesResponse> responseObserver) {
-    val countries = programService.listCountries();
+    val countries = serviceFacade.listCountries();
     val listCountriesResponse = programConverter.countryEntitiesToListCountriesResponse(countries);
     responseObserver.onNext(listCountriesResponse);
     responseObserver.onCompleted();
@@ -326,31 +229,31 @@ public class ProgramServiceImpl extends ProgramServiceGrpc.ProgramServiceImplBas
 
   @Override
   public void listRegions(Empty request, StreamObserver<ListRegionsResponse> responseObserver) {
-    val regions = programService.listRegions();
+    val regions = serviceFacade.listRegions();
     val listRegionsResponse = programConverter.regionEntitiesToListRegionsResponse(regions);
     responseObserver.onNext(listRegionsResponse);
     responseObserver.onCompleted();
   }
 
   @Override
-  public void listInstitutions(Empty request, StreamObserver<ListInstitutionsResponse> responseObserver) {
-    val institutions = programService.listInstitutions();
-    val listInstitutionsResponse = programConverter.institutionEntitiesToListInstitutionsResponse(institutions);
+  public void listInstitutions(
+      Empty request, StreamObserver<ListInstitutionsResponse> responseObserver) {
+    val institutions = serviceFacade.listInstitutions();
+    val listInstitutionsResponse =
+        programConverter.institutionEntitiesToListInstitutionsResponse(institutions);
     responseObserver.onNext(listInstitutionsResponse);
     responseObserver.onCompleted();
   }
 
-  private String getExceptionMessage(NestedRuntimeException e) {
-    return e.getMostSpecificCause().getMessage();
-  }
-
   @Override
-  public void addInstitutions(AddInstitutionsRequest request,
-    StreamObserver<AddInstitutionsResponse> responseObserver) {
-    val names = request.getNamesList().stream().map(name -> commonConverter.unboxStringValue(name))
-      .collect(toImmutableList());
+  public void addInstitutions(
+      AddInstitutionsRequest request, StreamObserver<AddInstitutionsResponse> responseObserver) {
+    val names =
+        request.getNamesList().stream()
+            .map(commonConverter::unboxStringValue)
+            .collect(toImmutableList());
     try {
-      val institutions = programService.addInstitutions(names);
+      val institutions = serviceFacade.addInstitutions(names);
       val response = programConverter.institutionsToAddInstitutionsResponse(institutions);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
@@ -361,18 +264,39 @@ public class ProgramServiceImpl extends ProgramServiceGrpc.ProgramServiceImplBas
   }
 
   @Override
-  @Transactional
-  public void getJoinProgramInvite(GetJoinProgramInviteRequest request,
-    StreamObserver<GetJoinProgramInviteResponse> responseObserver) {
-    val joinProgramInvite = invitationService.getInvitationById(UUID.fromString(request.getInviteId().getValue()));
-    if (joinProgramInvite.isEmpty()) {
-      responseObserver.onError(Status.NOT_FOUND.withDescription("Invitation is not found").asRuntimeException());
-      return;
-    }
-    val invitation = programConverter.joinProgramInviteEntityToJoinProgramInvite(joinProgramInvite.get());
+  public void getJoinProgramInvite(
+      GetJoinProgramInviteRequest request,
+      StreamObserver<GetJoinProgramInviteResponse> responseObserver) {
+    val joinProgramInvite =
+        serviceFacade
+            .getInvitationById(UUID.fromString(request.getInviteId().getValue()))
+            .orElseThrow(
+                () ->
+                    Status.NOT_FOUND
+                        .withDescription("Invitation is not found")
+                        .asRuntimeException());
+    val invitation = programConverter.joinProgramInviteEntityToJoinProgramInvite(joinProgramInvite);
     val response = GetJoinProgramInviteResponse.newBuilder().setInvitation(invitation).build();
     responseObserver.onNext(response);
     responseObserver.onCompleted();
   }
 
+  private StatusRuntimeException status(Status code, String message) {
+    return code.augmentDescription(message).asRuntimeException();
+  }
+
+  private StatusRuntimeException status(Throwable throwable) {
+    if (throwable instanceof StatusRuntimeException) {
+      return (StatusRuntimeException) throwable;
+    }
+
+    return Status.UNKNOWN
+        .withCause(throwable)
+        .augmentDescription(throwable.getMessage())
+        .asRuntimeException();
+  }
+
+  private String getExceptionMessage(NestedRuntimeException e) {
+    return e.getMostSpecificCause().getMessage();
+  }
 }

--- a/src/main/java/org/icgc/argo/program_service/properties/AppProperties.java
+++ b/src/main/java/org/icgc/argo/program_service/properties/AppProperties.java
@@ -22,17 +22,15 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.velocity.app.VelocityEngine;
-import org.icgc.argo.program_service.services.EgoAuthorizationService;
+import org.icgc.argo.program_service.services.auth.EgoAuthorizationService;
 import org.icgc.argo.program_service.utils.NoOpJavaMailSender;
 import org.icgc.argo.program_service.services.ego.EgoClient;
 import java.security.interfaces.RSAPublicKey;
 
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Component;

--- a/src/main/java/org/icgc/argo/program_service/services/ProgramServiceFacade.java
+++ b/src/main/java/org/icgc/argo/program_service/services/ProgramServiceFacade.java
@@ -1,0 +1,205 @@
+package org.icgc.argo.program_service.services;
+
+import io.grpc.Status;
+import lombok.NonNull;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import org.icgc.argo.program_service.converter.CommonConverter;
+import org.icgc.argo.program_service.converter.ProgramConverter;
+import org.icgc.argo.program_service.model.entity.*;
+import org.icgc.argo.program_service.proto.*;
+import org.icgc.argo.program_service.services.ego.EgoService;
+import org.icgc.argo.program_service.services.ego.model.entity.EgoUser;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import static io.grpc.Status.NOT_FOUND;
+import static java.lang.String.format;
+import static org.icgc.argo.program_service.utils.CollectionUtils.*;
+
+@Slf4j
+@Service
+public class ProgramServiceFacade {
+
+  /** Dependencies */
+  private final ProgramService programService;
+
+  private final EgoService egoService;
+  private final InvitationService invitationService;
+  private final ProgramConverter programConverter;
+  private final CommonConverter commonConverter;
+  private final ValidationService validationService;
+
+  @Autowired
+  public ProgramServiceFacade(
+      @NonNull ProgramService programService,
+      @NonNull EgoService egoService,
+      @NonNull InvitationService invitationService,
+      @NonNull ProgramConverter programConverter,
+      @NonNull CommonConverter commonConverter,
+      @NonNull ValidationService validationService) {
+    this.programService = programService;
+    this.egoService = egoService;
+    this.invitationService = invitationService;
+    this.programConverter = programConverter;
+    this.commonConverter = commonConverter;
+    this.validationService = validationService;
+  }
+
+  @Transactional
+  public ProgramEntity createProgram(CreateProgramRequest request) {
+    val errors = validationService.validateCreateProgramRequest(request);
+    if (errors.size() != 0) {
+      throw Status.INVALID_ARGUMENT
+          .augmentDescription(
+              format("Cannot create program: Program errors are [%s]", join(errors, ",")))
+          .asRuntimeException();
+    }
+
+    val program = request.getProgram();
+    val admins = request.getAdminsList();
+
+    // TODO: Refactor this, having a transactional side effect is no longer needed thanks to the
+    // facade
+    val programEntity =
+        programService.createWithSideEffectTransactional(
+            program,
+            (ProgramEntity pe) -> {
+              egoService.setUpProgram(pe.getShortName());
+              admins.forEach(
+                  admin -> {
+                    val email = commonConverter.unboxStringValue(admin.getEmail());
+                    val firstName = commonConverter.unboxStringValue(admin.getFirstName());
+                    val lastName = commonConverter.unboxStringValue(admin.getLastName());
+                    egoService.getOrCreateUser(email, firstName, lastName);
+                    invitationService.inviteUser(pe, email, firstName, lastName, UserRole.ADMIN);
+                  });
+            });
+    log.debug("Created {}", programEntity.getShortName());
+    return programEntity;
+  }
+
+  @Transactional
+  public ProgramEntity getProgram(GetProgramRequest request) {
+    val shortName = request.getShortName().getValue();
+    return programService.getProgram(shortName);
+  }
+
+  @Transactional
+  public ProgramEntity updateProgram(UpdateProgramRequest request) {
+    val program = request.getProgram();
+    val updatingProgram = programConverter.programToProgramEntity(program);
+    return programService.updateProgram(
+        updatingProgram,
+        program.getCancerTypesList(),
+        program.getPrimarySitesList(),
+        program.getInstitutionsList(),
+        program.getCountriesList(),
+        program.getRegionsList());
+  }
+
+  @Transactional
+  public UUID inviteUser(InviteUserRequest request) {
+    val programShortName = request.getProgramShortName().getValue();
+    val programResult = programService.getProgram(programShortName);
+
+    val email = commonConverter.unboxStringValue(request.getEmail());
+    val firstName = commonConverter.unboxStringValue(request.getFirstName());
+    val lastName = commonConverter.unboxStringValue(request.getLastName());
+
+    egoService.getOrCreateUser(email, firstName, lastName);
+
+    return invitationService.inviteUser(programResult, email, firstName, lastName, request.getRole().getValue());
+  }
+
+  @Transactional
+  public EgoUser joinProgram(JoinProgramRequest request, Consumer<JoinProgramInviteEntity> condition) {
+    val str = request.getJoinProgramInvitationId().getValue();
+    val id = commonConverter.stringToUUID(str);
+
+    val invitation = invitationService.getInvitationById(id).orElseThrow(NOT_FOUND::asRuntimeException);
+    condition.accept(invitation);
+
+    return invitationService.acceptInvite(id);
+  }
+
+  @Transactional
+  public List<ProgramEntity> listPrograms() {
+    return programService.listPrograms();
+  }
+
+  @Transactional
+  public Set<UserDetails> listUsers(String programShortName) {
+    val users = egoService.getUsersInProgram(programShortName);
+    Set<UserDetails> userDetails = mapToSet(users,
+      user -> programConverter.userWithOptionalJoinProgramInviteToUserDetails(user,
+        invitationService.getLatestInvitation(programShortName, user.getEmail().getValue())));
+    userDetails.addAll(mapToList(invitationService.listPendingInvitations(programShortName),
+      programConverter::joinProgramInviteToUserDetails));
+
+    return userDetails;
+  }
+
+  @Transactional
+  public void removeUser(RemoveUserRequest request) {
+    val programName = request.getProgramShortName().getValue();
+    val email = request.getUserEmail().getValue();
+    invitationService.revoke(programName, email);
+    egoService.leaveProgram(email, programName);
+  }
+
+  @Transactional
+  public void updateUser(UpdateUserRequest request) {
+    val programShortName = request.getShortName().getValue();
+    val email = request.getUserEmail().getValue();
+    val role = request.getRole().getValue();
+
+    egoService.updateUserRole(email, programShortName, role);
+  }
+
+  @Transactional
+  public void removeProgram(RemoveProgramRequest request) {
+    val shortName = request.getProgramShortName().getValue();
+    egoService.cleanUpProgram(shortName);
+    programService.removeProgram(request.getProgramShortName().getValue());
+  }
+
+  public List<CancerEntity> listCancers() {
+    return programService.listCancers();
+  }
+
+  public List<PrimarySiteEntity> listPrimarySites() {
+    return programService.listPrimarySites();
+  }
+
+  public List<CountryEntity> listCountries() {
+    return programService.listCountries();
+  }
+
+  public List<RegionEntity> listRegions() {
+    return programService.listRegions();
+  }
+
+  public List<InstitutionEntity> listInstitutions() {
+    return programService.listInstitutions();
+  }
+
+  @Transactional
+  public List<InstitutionEntity> addInstitutions(List<String> names) {
+    return programService.addInstitutions(names);
+  }
+
+  @Transactional
+  public Optional<JoinProgramInviteEntity> getInvitationById(UUID id) {
+    return invitationService.getInvitationById(id);
+  }
+
+}

--- a/src/main/java/org/icgc/argo/program_service/services/auth/AuthorizationService.java
+++ b/src/main/java/org/icgc/argo/program_service/services/auth/AuthorizationService.java
@@ -1,4 +1,4 @@
-package org.icgc.argo.program_service.services;
+package org.icgc.argo.program_service.services.auth;
 
 import io.grpc.Status;
 

--- a/src/main/java/org/icgc/argo/program_service/services/auth/DummyAuthorizationService.java
+++ b/src/main/java/org/icgc/argo/program_service/services/auth/DummyAuthorizationService.java
@@ -1,4 +1,4 @@
-package org.icgc.argo.program_service.services;
+package org.icgc.argo.program_service.services.auth;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;

--- a/src/main/java/org/icgc/argo/program_service/services/auth/EgoAuthorizationService.java
+++ b/src/main/java/org/icgc/argo/program_service/services/auth/EgoAuthorizationService.java
@@ -1,4 +1,4 @@
-package org.icgc.argo.program_service.services;
+package org.icgc.argo.program_service.services.auth;
 
 import io.grpc.Status;
 import lombok.extern.slf4j.Slf4j;

--- a/src/test/java/org/icgc/argo/program_service/services/auth/AuthorizationServiceTest.java
+++ b/src/test/java/org/icgc/argo/program_service/services/auth/AuthorizationServiceTest.java
@@ -1,8 +1,10 @@
-package org.icgc.argo.program_service.services;
+package org.icgc.argo.program_service.services.auth;
 
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import lombok.val;
+import org.icgc.argo.program_service.services.auth.AuthorizationService;
+import org.icgc.argo.program_service.services.auth.EgoAuthorizationService;
 import org.icgc.argo.program_service.services.ego.model.entity.EgoToken;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/org/icgc/argo/program_service/services/ego/EgoServiceIT.java
+++ b/src/test/java/org/icgc/argo/program_service/services/ego/EgoServiceIT.java
@@ -16,7 +16,7 @@
  *
  */
 
-package org.icgc.argo.program_service.services;
+package org.icgc.argo.program_service.services.ego;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import lombok.extern.slf4j.Slf4j;

--- a/src/test/java/org/icgc/argo/program_service/services/ego/EgoServiceTest.java
+++ b/src/test/java/org/icgc/argo/program_service/services/ego/EgoServiceTest.java
@@ -16,7 +16,7 @@
  *
  */
 
-package org.icgc.argo.program_service.services;
+package org.icgc.argo.program_service.services.ego;
 
 import lombok.val;
 import org.icgc.argo.program_service.Utils;


### PR DESCRIPTION
# Summary
gRPC services cannot be transactional as their communication is stream based, so they will communicate a response to the caller over the stream before their method execution is finished, bumped from the stack, and the transaction committed. 

## Changes
- Service Facade 
  - Transactional where required with guarantee that the transaction is committed on return from call. 
  - Encapsulate all service stitching business logic away from the gRPC presentation layer. gRPC class is no longer aware of what services are being called under the hood
- Code style fixes changes (public methods before private)
- Test updates, including fixing a test that was ignored
- Use handy monad-ness of optionals and use `.orElseThrow` for control flow rather than clunky if/else
- package reorg