### PR TITLE
Eliminates mapstruct/converter/entity from grpc layer

### DIFF
--- a/src/main/java/org/icgc/argo/program_service/grpc/interceptor/ExceptionListener.java
+++ b/src/main/java/org/icgc/argo/program_service/grpc/interceptor/ExceptionListener.java
@@ -5,8 +5,8 @@ import io.grpc.ServerCall;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
-import org.icgc.argo.program_service.utils.Joiners;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.transaction.TransactionSystemException;
 
@@ -14,6 +14,7 @@ import javax.validation.ConstraintViolationException;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
+@Slf4j
 @AllArgsConstructor
 public class ExceptionListener<ReqT, RespT> extends ServerCall.Listener<ReqT> {
   private final ServerCall<ReqT, RespT> call;
@@ -26,7 +27,7 @@ public class ExceptionListener<ReqT, RespT> extends ServerCall.Listener<ReqT> {
    * 1,000 bytes for the name plus any other meta-data that gets thrown into the headers, we have 7192 bytes
    * available for the stack trace, so we need to truncate it if it's longer than that.
    */
-  private final int MAX_STACKTRACE_SIZE = 7192;
+  private static final int MAX_STACKTRACE_SIZE = 7192;
 
   @Override
   public void onMessage(ReqT message) {
@@ -74,6 +75,7 @@ public class ExceptionListener<ReqT, RespT> extends ServerCall.Listener<ReqT> {
   }
 
   private void closeWithException(Throwable t) {
+    log.error("Closing with exception", t);
     StatusRuntimeException exception = getException(getCause(t));
 
     Metadata metadata = exception.getTrailers();

--- a/src/test/java/org/icgc/argo/program_service/grpc/ProgramServiceAuthorizationTest.java
+++ b/src/test/java/org/icgc/argo/program_service/grpc/ProgramServiceAuthorizationTest.java
@@ -112,7 +112,6 @@ public class ProgramServiceAuthorizationTest {
 
     val service =
         new ProgramServiceImpl(
-            programConverter,
             commonConverter,
             authorizationService,
             facade);

--- a/src/test/java/org/icgc/argo/program_service/grpc/ProgramServiceGrpcIT.java
+++ b/src/test/java/org/icgc/argo/program_service/grpc/ProgramServiceGrpcIT.java
@@ -101,9 +101,10 @@ public class ProgramServiceGrpcIT {
   }
 
   @Test
-  public void createProgram() {
+  public void createProgramAndGet() {
+    val shortName = stringValue(randomProgramName());
     val program = Program.newBuilder()
-      .setShortName(stringValue(randomProgramName()))
+      .setShortName(shortName)
       .setMembershipType(membershipTypeValue(ASSOCIATE))
       .setWebsite(stringValue("http://site.org"))
       .addInstitutions("Ontario Institute for Cancer Research")
@@ -126,6 +127,10 @@ public class ProgramServiceGrpcIT {
     val createProgramRequest = CreateProgramRequest.newBuilder().setProgram(program).addAllAdmins(admins).build();
     val response = stub.createProgram(createProgramRequest);
     assertFalse(isEmpty(response.getCreatedAt()));
+
+    val getProgramRequest = GetProgramRequest.newBuilder().setShortName(shortName).build();
+    val getResponse = stub.getProgram(getProgramRequest);
+    assertEquals(shortName.getValue(), getResponse.getProgram().getProgram().getShortName().getValue());
   }
 
   boolean isEmpty(Object o) {

--- a/src/test/java/org/icgc/argo/program_service/grpc/ProgramServiceImplTest.java
+++ b/src/test/java/org/icgc/argo/program_service/grpc/ProgramServiceImplTest.java
@@ -60,8 +60,6 @@ class ProgramServiceImplTest {
   InvitationService invitationService = mock(InvitationService.class);
   EgoService egoService = mock(EgoService.class);
   AuthorizationService authorizationService = mock(AuthorizationService.class);
-  ValidationProperties properties = new ValidationProperties();
-  ValidatorFactory validatorFactory = properties.factory();
   ValidationService validationService = mock(ValidationService.class);
   ProgramServiceFacade facade =
       new ProgramServiceFacade(
@@ -73,7 +71,6 @@ class ProgramServiceImplTest {
           validationService);
   ProgramServiceImpl programServiceImpl =
       new ProgramServiceImpl(
-          programConverter,
           CommonConverter.INSTANCE,
           authorizationService,
           facade);
@@ -431,8 +428,7 @@ class ProgramServiceImplTest {
             programConverter,
             CommonConverter.INSTANCE,
             validationService);
-    return new ProgramServiceImpl(
-        programConverter, CommonConverter.INSTANCE, authorizationService, newFacade);
+    return new ProgramServiceImpl(CommonConverter.INSTANCE, authorizationService, newFacade);
   }
 
   ListUsersRequest createListUsersRequest(String shortName) {


### PR DESCRIPTION
### Problem
13 INTERNAL: failed to lazily initialize a collection of role: org.icgc.argo.program_service.model.entity.ProgramEntity.programCancers, could not initialize proxy - no Session

### Why
Our usage of mapstruct in the `ProgramConverter` was session/thread unsafe as during serialization it would go back to the database. This meant that when the transactions were correctly implemented and committing themselves they would close the session on their thread causing the `ProgramConverter` `@AfterMapping` to fail

### Fix
 - Push all `ProgramConverter` calls into transactional facade layer and eliminate converter and entity references from gRPC layer
 - Add an Integration to see if we can actually retrieve a program that was created. 
 - Add logging of stackstrace when throwable causes closed connection