### PR TITLE
✨ extends join program expiry to 30 days

### DIFF
--- a/src/main/java/org/icgc/argo/program_service/model/entity/JoinProgramInviteEntity.java
+++ b/src/main/java/org/icgc/argo/program_service/model/entity/JoinProgramInviteEntity.java
@@ -92,7 +92,7 @@ public class JoinProgramInviteEntity {
 
   public JoinProgramInviteEntity(ProgramEntity program, String userEmail, String firstName, String lastName, UserRole role) {
     this.createdAt = LocalDateTime.now(ZoneOffset.UTC);
-    this.expiresAt = this.createdAt.plusHours(48);
+    this.expiresAt = this.createdAt.plusDays(30);
     this.acceptedAt = null;
 
     this.program = program;


### PR DESCRIPTION
This could be parameterized to config but it probably will never change, so we're keeping it hard-coded for simplicity