### PR TITLE
Docker compatible with Mac architecture; cleanup dev scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ###################################
 #   Maven Builder
 ###################################
-FROM adoptopenjdk/openjdk11:jdk-11.0.6_10-alpine-slim as builder
+FROM adoptopenjdk/openjdk11:jdk-11.0.6_10-slim as builder
 
 WORKDIR /srv
 
@@ -12,7 +12,7 @@ RUN ./mvnw package -Dmaven.test.skip=true
 ###################################
 #   Server
 ###################################
-FROM adoptopenjdk/openjdk11:jre-11.0.6_10-alpine
+FROM adoptopenjdk/openjdk11:jre-11.0.6_10
 
 ENV APP_USER app
 ENV APP_UID 9999
@@ -21,8 +21,8 @@ ENV APP_HOME /home/$APP_USER
 
 COPY --from=builder /srv/target/program-service-*.jar /program-service.jar
 
-RUN addgroup -S -g $APP_GID $APP_USER  \
-	&& adduser -S -u $APP_UID -G $APP_USER $APP_USER \
+RUN addgroup --system --gid $APP_GID $APP_USER  \
+	&& adduser --system --uid $APP_UID --ingroup $APP_USER $APP_USER \
 	&& mkdir -p $APP_HOME \
 	&& chown -R $APP_UID:$APP_GID $APP_HOME \
 	&& chown $APP_UID:$APP_GID /program-service.jar \

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ package: _check_mvn_software_exists
 #######################################
 dev-start: _check_docker_software_exists
 	@echo $(YELLOW)$(INFO_HEADER) "Starting DEV mode with ego and admin services"$(END)
-	@$(DOCKER_COMPOSE_COMMAND) up --no-deps -d ego-api ego-postgres admin
+	@$(DOCKER_COMPOSE_COMMAND) up --no-deps -d ego-api ego-postgres admin postgres
 	@echo $(DONE_MESSAGE)
 
 dev-stop: _check_docker_software_exists

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ To publish, you need to have a [NPMJS](https://www.npmjs.com) account and be a m
 Run postgres at port 5432
 
 ```sh
+make dev-start
+```
+```sh
 docker run --name postgres -d -p 5432:5432 postgres
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,6 @@
 version: '3.2'
 services:
   api:
-    restart: always
     build:
       context: ./
       dockerfile: Dockerfile
@@ -65,7 +64,6 @@ services:
     ports:
       - "9432:5432"
   ego-api:
-    restart: always
     image: "overture/ego:latest"
     environment:
       SERVER_PORT: 8080

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 		<!-- Dependency Versions -->
 		<java.version>11</java.version>
 		<mapstruct.version>1.3.0.Final</mapstruct.version>
-		<lombok.version>1.18.8</lombok.version>
+		<lombok.version>1.18.24</lombok.version>
 		<postgres.version>42.2.5</postgres.version>
 		<flyway.version>5.2.4</flyway.version>
 		<javax.validation.version>2.0.1.Final</javax.validation.version>
@@ -50,7 +50,7 @@
 		<jackson.version>2.13.2</jackson.version>
 		<jwt.version>3.8.0</jwt.version>
 		<aspectj.version>1.9.2</aspectj.version>
-		<grpc.version>1.20.0</grpc.version>
+		<grpc.version>1.52.1</grpc.version>
 		<javax.mail.version>1.6.2</javax.mail.version>
 		<testcontainers.version>1.12.5</testcontainers.version>
 		<junit.jupiter.version>5.7.1</junit.jupiter.version>
@@ -67,7 +67,7 @@
 		<plugin.protobuf.version>0.6.1</plugin.protobuf.version>
 		<plugin.kr.motd.version>1.6.1</plugin.kr.motd.version>
 		<plugin.failsafe.version>2.22.1</plugin.failsafe.version>
-		<plugin.protoc.version>3.6.1</plugin.protoc.version>
+		<plugin.protoc.version>3.21.12</plugin.protoc.version>
 	</properties>
 
 	<dependencies>
@@ -392,14 +392,14 @@
 					<target>${java.version}</target>
 					<annotationProcessorPaths>
 						<path>
-							<groupId>org.mapstruct</groupId>
-							<artifactId>mapstruct-processor</artifactId>
-							<version>${mapstruct.version}</version>
-						</path>
-						<path>
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
 							<version>${lombok.version}</version>
+						</path>
+						<path>
+							<groupId>org.mapstruct</groupId>
+							<artifactId>mapstruct-processor</artifactId>
+							<version>${mapstruct.version}</version>
 						</path>
 						<path>
 							<groupId>org.springframework.boot</groupId>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
     enabled: false
     locations: "classpath:flyway/sql"
   datasource:
-    url: jdbc:postgresql://localhost:5432/program_db
+    url: jdbc:postgresql://localhost:9432/program_db
     username: postgres
     password: password
   mail:


### PR DESCRIPTION
The alpine JDK docker image has compatibility issues with ARM architecture devices (Apple Silicon), switching to a non-alpine base image should provide a bit more stability when running on Macs.

As part of the change, some libraries needed updating due to the old versions no longer being available on Maven. These changes are included as well.