### PR TITLE
Fix for /programs/joinProgramInvite endpoint 

### DIFF
--- a/src/main/java/org/icgc/argo/program_service/controller/ProgramController.java
+++ b/src/main/java/org/icgc/argo/program_service/controller/ProgramController.java
@@ -233,14 +233,14 @@ public class ProgramController {
     }
   }
 
-  @GetMapping(value = "/joinProgramInvite")
+  @GetMapping(value = "/joinProgramInvite/{invite_id}")
   public ResponseEntity<GetJoinProgramInviteResponseDTO> getJoinProgramInvite(
       @Parameter(hidden = true) @RequestHeader(value = "Authorization", required = true)
           final String authorization,
-      @RequestBody GetJoinProgramInviteRequestDTO getJoinProgramInviteRequestDTO) {
+      @PathVariable(value = "invite_id", required = true) String inviteId) {
     val invitation =
         serviceFacade.getInvitationById(
-            UUID.fromString(getJoinProgramInviteRequestDTO.getInviteId()));
+                UUID.fromString(inviteId));
     GetJoinProgramInviteResponseDTO getJoinProgramInviteResponseDTO =
         new GetJoinProgramInviteResponseDTO();
     getJoinProgramInviteResponseDTO.setInvitation(


### PR DESCRIPTION
These changes enable the controller to process GET requests for /programs/joinProgramInvite endpoint, ensuring the presence of an "Authorization" header and using the invite_id from the URL to fetch the corresponding program.
<img width="1417" alt="Screenshot 2023-10-11 at 12 27 58 PM" src="https://github.com/icgc-argo/program-service/assets/121898125/a2c54238-e816-4f1a-9e24-ea35392ad028">
