### PR TITLE
Changes related to "Modify Create Program endpoint to require Data Center id"

### DIFF
--- a/src/main/java/org/icgc/argo/program_service/controller/DataCenterController.java
+++ b/src/main/java/org/icgc/argo/program_service/controller/DataCenterController.java
@@ -31,7 +31,7 @@ public class DataCenterController {
     return new ResponseEntity(dataCenterEntities, HttpStatus.OK);
   }
 
-  @GetMapping(value = "/datacenters/{datacenter_short_name}/programs")
+  @GetMapping(value = "/{datacenter_short_name}/programs")
   public ResponseEntity<ProgramsResponseDTO> listDataCenterPrograms(
       @Parameter(hidden = true) @RequestHeader(value = "Authorization", required = true)
           final String authorization,
@@ -42,7 +42,7 @@ public class DataCenterController {
         grpc2JsonConverter.prepareListProgramsResponse(listProgramsResponse), HttpStatus.OK);
   }
 
-  @PostMapping(value = "/datacenters")
+  @PostMapping
   public ResponseEntity<DataCenterDTO> createDataCenter(
       @Parameter(hidden = true) @RequestHeader(value = "Authorization", required = true)
           final String authorization,
@@ -52,7 +52,7 @@ public class DataCenterController {
     return new ResponseEntity(dataCenterEntity, HttpStatus.OK);
   }
 
-  @PatchMapping(value = "/datacenters/{datacenter_short_name}")
+  @PatchMapping(value = "/{datacenter_short_name}")
   public ResponseEntity<DataCenterDTO> updateDataCenter(
       @Parameter(hidden = true) @RequestHeader(value = "Authorization", required = true)
           final String authorization,

--- a/src/main/java/org/icgc/argo/program_service/controller/ProgramController.java
+++ b/src/main/java/org/icgc/argo/program_service/controller/ProgramController.java
@@ -43,7 +43,8 @@ public class ProgramController {
         grpc2JsonConverter.fromJson(
             grpc2JsonConverter.getJsonFromObject(createProgramRequestDTO),
             CreateProgramRequest.class);
-    CreateProgramResponse response = serviceFacade.createProgram(request);
+    CreateProgramResponse response =
+        serviceFacade.createProgram(request, createProgramRequestDTO.getDataCenterId());
     return new ResponseEntity(
         grpc2JsonConverter.prepareCreateProgramResponse(response), HttpStatus.CREATED);
   }

--- a/src/main/java/org/icgc/argo/program_service/exception/ExceptionHandlers.java
+++ b/src/main/java/org/icgc/argo/program_service/exception/ExceptionHandlers.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.icgc.argo.program_service.model.exceptions.BadRequestException;
 import org.icgc.argo.program_service.model.exceptions.ForbiddenException;
 import org.icgc.argo.program_service.model.exceptions.NotFoundException;
 import org.icgc.argo.program_service.model.exceptions.UnauthorizedException;
@@ -62,5 +63,20 @@ public class ExceptionHandlers {
             "error", NOT_FOUND.getReasonPhrase()),
         new HttpHeaders(),
         NOT_FOUND);
+  }
+
+  @ExceptionHandler(BadRequestException.class)
+  public ResponseEntity<Object> handleForbiddenException(
+      HttpServletRequest req, BadRequestException ex) {
+    val message = ex.getMessage();
+    log.error(message);
+    return new ResponseEntity<Object>(
+        Map.of(
+            "message", ex.getMessage(),
+            "timestamp", new Date(),
+            "path", req.getServletPath(),
+            "error", BAD_REQUEST.getReasonPhrase()),
+        new HttpHeaders(),
+        BAD_REQUEST);
   }
 }

--- a/src/main/java/org/icgc/argo/program_service/exception/ExceptionHandlers.java
+++ b/src/main/java/org/icgc/argo/program_service/exception/ExceptionHandlers.java
@@ -7,10 +7,7 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
-import org.icgc.argo.program_service.model.exceptions.BadRequestException;
-import org.icgc.argo.program_service.model.exceptions.ForbiddenException;
-import org.icgc.argo.program_service.model.exceptions.NotFoundException;
-import org.icgc.argo.program_service.model.exceptions.UnauthorizedException;
+import org.icgc.argo.program_service.model.exceptions.*;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -66,7 +63,7 @@ public class ExceptionHandlers {
   }
 
   @ExceptionHandler(BadRequestException.class)
-  public ResponseEntity<Object> handleForbiddenException(
+  public ResponseEntity<Object> handleBadRequestException(
       HttpServletRequest req, BadRequestException ex) {
     val message = ex.getMessage();
     log.error(message);
@@ -78,5 +75,20 @@ public class ExceptionHandlers {
             "error", BAD_REQUEST.getReasonPhrase()),
         new HttpHeaders(),
         BAD_REQUEST);
+  }
+
+  @ExceptionHandler(RecordNotFoundException.class)
+  public ResponseEntity<Object> handleRecordNotFoundException(
+          HttpServletRequest req, RecordNotFoundException ex) {
+    val message = ex.getMessage();
+    log.error(message);
+    return new ResponseEntity<Object>(
+            Map.of(
+                    "message", ex.getMessage(),
+                    "timestamp", new Date(),
+                    "path", req.getServletPath(),
+                    "error", BAD_REQUEST.getReasonPhrase()),
+            new HttpHeaders(),
+            BAD_REQUEST);
   }
 }

--- a/src/main/java/org/icgc/argo/program_service/model/dto/CreateProgramRequestDTO.java
+++ b/src/main/java/org/icgc/argo/program_service/model/dto/CreateProgramRequestDTO.java
@@ -1,6 +1,7 @@
 package org.icgc.argo.program_service.model.dto;
 
 import java.util.List;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -13,5 +14,6 @@ import lombok.NoArgsConstructor;
 public class CreateProgramRequestDTO {
 
   private Program program;
+  private UUID dataCenterId;
   List<UserDTO> admins;
 }

--- a/src/main/java/org/icgc/argo/program_service/model/exceptions/BadRequestException.java
+++ b/src/main/java/org/icgc/argo/program_service/model/exceptions/BadRequestException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of the GNU Affero General Public License v3.0.
+ * You should have received a copy of the GNU Affero General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ */
+
+package org.icgc.argo.program_service.model.exceptions;
+
+import lombok.NonNull;
+
+public class BadRequestException extends RuntimeException {
+
+  public BadRequestException(@NonNull String message) {
+    super(message);
+  }
+
+  public static void checkNotFound(
+      boolean expression, @NonNull String message, @NonNull Object... args) {
+    if (!expression) {
+      throw new BadRequestException(String.format(message, args));
+    }
+  }
+}

--- a/src/main/java/org/icgc/argo/program_service/model/exceptions/BadRequestException.java
+++ b/src/main/java/org/icgc/argo/program_service/model/exceptions/BadRequestException.java
@@ -1,17 +1,19 @@
 /*
- * Copyright (c) 2023. The Ontario Institute for Cancer Research. All rights reserved.
+ * Copyright (c) 2023 The Ontario Institute for Cancer Research. All rights reserved
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * This program and the accompanying materials are made available under the terms of the GNU Affero General Public License v3.0.
+ * You should have received a copy of the GNU Affero General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  *
  */

--- a/src/main/java/org/icgc/argo/program_service/model/exceptions/ForbiddenException.java
+++ b/src/main/java/org/icgc/argo/program_service/model/exceptions/ForbiddenException.java
@@ -1,17 +1,20 @@
 /*
- * Copyright (c) 2019. The Ontario Institute for Cancer Research. All rights reserved.
+ * Copyright (c) 2023 The Ontario Institute for Cancer Research. All rights reserved
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * This program and the accompanying materials are made available under the terms of the GNU Affero General Public License v3.0.
+ * You should have received a copy of the GNU Affero General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
  *
  */
 

--- a/src/main/java/org/icgc/argo/program_service/model/exceptions/ProgramRuntimeException.java
+++ b/src/main/java/org/icgc/argo/program_service/model/exceptions/ProgramRuntimeException.java
@@ -1,17 +1,19 @@
 /*
- * Copyright (c) 2023. The Ontario Institute for Cancer Research. All rights reserved.
+ * Copyright (c) 2023 The Ontario Institute for Cancer Research. All rights reserved
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * This program and the accompanying materials are made available under the terms of the GNU Affero General Public License v3.0.
+ * You should have received a copy of the GNU Affero General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  *
  */

--- a/src/main/java/org/icgc/argo/program_service/model/exceptions/ProgramRuntimeException.java
+++ b/src/main/java/org/icgc/argo/program_service/model/exceptions/ProgramRuntimeException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023. The Ontario Institute for Cancer Research. All rights reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ */
+
+package org.icgc.argo.program_service.model.exceptions;
+
+import lombok.NonNull;
+
+public class ProgramRuntimeException extends RuntimeException {
+
+  public ProgramRuntimeException(@NonNull String message) {
+    super(message);
+  }
+
+
+  public static void checkNotFound(
+      boolean expression, @NonNull String message, @NonNull Object... args) {
+    if (!expression) {
+      throw new ProgramRuntimeException(String.format(message, args));
+    }
+  }
+}

--- a/src/main/java/org/icgc/argo/program_service/model/exceptions/RecordNotFoundException.java
+++ b/src/main/java/org/icgc/argo/program_service/model/exceptions/RecordNotFoundException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of the GNU Affero General Public License v3.0.
+ * You should have received a copy of the GNU Affero General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ */
+
+package org.icgc.argo.program_service.model.exceptions;
+
+import lombok.NonNull;
+
+public class RecordNotFoundException extends RuntimeException {
+
+  public RecordNotFoundException(@NonNull String message) {
+    super(message);
+  }
+
+  public static void checkNotFound(
+      boolean expression, @NonNull String message, @NonNull Object... args) {
+    if (!expression) {
+      throw new RecordNotFoundException(String.format(message, args));
+    }
+  }
+}

--- a/src/main/java/org/icgc/argo/program_service/model/exceptions/UnauthorizedException.java
+++ b/src/main/java/org/icgc/argo/program_service/model/exceptions/UnauthorizedException.java
@@ -1,17 +1,20 @@
 /*
- * Copyright (c) 2019. The Ontario Institute for Cancer Research. All rights reserved.
+ * Copyright (c) 2023 The Ontario Institute for Cancer Research. All rights reserved
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * This program and the accompanying materials are made available under the terms of the GNU Affero General Public License v3.0.
+ * You should have received a copy of the GNU Affero General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
  *
  */
 

--- a/src/main/java/org/icgc/argo/program_service/security/JWTAuthorizationFilter.java
+++ b/src/main/java/org/icgc/argo/program_service/security/JWTAuthorizationFilter.java
@@ -1,17 +1,21 @@
 /*
- * Copyright (c) 2017. The Ontario Institute for Cancer Research. All rights reserved.
+ * Copyright (c) 2023 The Ontario Institute for Cancer Research. All rights reserved
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * This program and the accompanying materials are made available under the terms of the GNU Affero General Public License v3.0.
+ * You should have received a copy of the GNU Affero General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ *
  */
 
 package org.icgc.argo.program_service.security;

--- a/src/main/java/org/icgc/argo/program_service/services/ProgramService.java
+++ b/src/main/java/org/icgc/argo/program_service/services/ProgramService.java
@@ -188,7 +188,6 @@ public class ProgramService {
     val p = programRepository.save(programEntity);
     val cancers = cancerRepository.findAllByNameIn(program.getCancerTypesList());
     val primarySites = primarySiteRepository.findAllByNameIn(program.getPrimarySitesList());
-    val regions = regionRepository.findAllByNameIn(program.getRegionsList());
     val countries = countryRepository.findAllByNameIn(program.getCountriesList());
     List<InstitutionEntity> institutions =
             institutionRepository.findAllByNameIn(program.getInstitutionsList());

--- a/src/main/java/org/icgc/argo/program_service/services/ProgramService.java
+++ b/src/main/java/org/icgc/argo/program_service/services/ProgramService.java
@@ -40,15 +40,19 @@ import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import javax.validation.ValidatorFactory;
+
+import io.netty.util.internal.StringUtil;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.apache.commons.lang.StringUtils;
 import org.icgc.argo.program_service.converter.DataCenterConverter;
 import org.icgc.argo.program_service.converter.ProgramConverter;
 import org.icgc.argo.program_service.model.dto.DataCenterRequestDTO;
 import org.icgc.argo.program_service.model.entity.*;
 import org.icgc.argo.program_service.model.exceptions.BadRequestException;
 import org.icgc.argo.program_service.model.exceptions.NotFoundException;
+import org.icgc.argo.program_service.model.exceptions.RecordNotFoundException;
 import org.icgc.argo.program_service.model.join.*;
 import org.icgc.argo.program_service.proto.Program;
 import org.icgc.argo.program_service.repositories.*;
@@ -176,8 +180,10 @@ public class ProgramService {
       if (!dataCenterEntity.isEmpty()) {
         programEntity.setDataCenterId(dataCenterId);
       } else {
-        throw new BadRequestException("DataCenterId '" + dataCenterId + "' not found");
+        throw new RecordNotFoundException("DataCenterId '" + dataCenterId + "' not found");
       }
+    } else {
+      throw new BadRequestException("DataCenterId cannot be null or empty");
     }
 
     val now = LocalDateTime.now(ZoneId.of("UTC"));

--- a/src/main/java/org/icgc/argo/program_service/services/ProgramService.java
+++ b/src/main/java/org/icgc/argo/program_service/services/ProgramService.java
@@ -165,27 +165,64 @@ public class ProgramService {
   }
 
   public ProgramEntity createWithSideEffect(
-      @NonNull Program program, Consumer<ProgramEntity> consumer, UUID dataCenterId) {
-    val programEntity = createProgram(program, dataCenterId);
+          @NonNull Program program, Consumer<ProgramEntity> consumer) {
+    val programEntity = createProgram(program);
     consumer.accept(programEntity);
     return programEntity;
   }
 
+  public ProgramEntity createWithSideEffect(
+          @NonNull Program program, Consumer<ProgramEntity> consumer, UUID dataCenterId) {
+    val programEntity = createProgram(program, dataCenterId);
+    consumer.accept(programEntity);
+    return programEntity;
+  }
+  public ProgramEntity createProgram(@NonNull Program program)
+          throws DataIntegrityViolationException {
+    val programEntity = programConverter.programToProgramEntity(program);
+
+    val now = LocalDateTime.now(ZoneId.of("UTC"));
+    programEntity.setCreatedAt(now);
+    programEntity.setUpdatedAt(now);
+
+    val p = programRepository.save(programEntity);
+    val cancers = cancerRepository.findAllByNameIn(program.getCancerTypesList());
+    val primarySites = primarySiteRepository.findAllByNameIn(program.getPrimarySitesList());
+    val regions = regionRepository.findAllByNameIn(program.getRegionsList());
+    val countries = countryRepository.findAllByNameIn(program.getCountriesList());
+    List<InstitutionEntity> institutions =
+            institutionRepository.findAllByNameIn(program.getInstitutionsList());
+    if (institutions.size() != program.getInstitutionsList().size()) {
+      institutions = filterAndAddInstitutions(program.getInstitutionsList());
+    }
+
+    List<ProgramCancer> programCancers = mapToList(cancers, x -> createProgramCancer(p, x).get());
+    List<ProgramPrimarySite> programPrimarySites =
+            mapToList(primarySites, x -> createProgramPrimarySite(p, x).get());
+    List<ProgramInstitution> programInstitutions =
+            mapToList(institutions, x -> createProgramInstitution(p, x).get());
+    List<ProgramCountry> programCountries =
+            mapToList(countries, x -> createProgramCountry(p, x).get());
+
+    programCancerRepository.saveAll(programCancers);
+    programPrimarySiteRepository.saveAll(programPrimarySites);
+    programInstitutionRepository.saveAll(programInstitutions);
+    programCountryRepository.saveAll(programCountries);
+
+    return programEntity;
+  }
   public ProgramEntity createProgram(@NonNull Program program, UUID dataCenterId)
       throws DataIntegrityViolationException {
     val programEntity = programConverter.programToProgramEntity(program);
 
-    if (dataCenterId != null) {
-      val dataCenterEntity = dataCenterRepository.findById(dataCenterId);
-      if (!dataCenterEntity.isEmpty()) {
-        programEntity.setDataCenterId(dataCenterId);
-      } else {
-        throw new RecordNotFoundException("DataCenterId '" + dataCenterId + "' not found");
-      }
-    } else {
+    if (dataCenterId == null) {
       throw new BadRequestException("DataCenterId cannot be null or empty");
     }
-
+    val dataCenterEntity = dataCenterRepository.findById(dataCenterId);
+    if (dataCenterEntity.isEmpty()) {
+      throw new RecordNotFoundException("DataCenterId '" + dataCenterId + "' not found");
+    }
+    programEntity.setDataCenterId(dataCenterId);
     val now = LocalDateTime.now(ZoneId.of("UTC"));
     programEntity.setCreatedAt(now);
     programEntity.setUpdatedAt(now);

--- a/src/main/java/org/icgc/argo/program_service/services/ProgramServiceFacade.java
+++ b/src/main/java/org/icgc/argo/program_service/services/ProgramServiceFacade.java
@@ -106,8 +106,7 @@ public class ProgramServiceFacade {
             program,
             (ProgramEntity pe) -> {
               initializeProgramInEgo(pe, admins);
-            },
-            null);
+            });
     log.debug("Created {}", programEntity.getShortName());
     return programConverter.programEntityToCreateProgramResponse(programEntity);
   }

--- a/src/main/java/org/icgc/argo/program_service/services/ProgramServiceFacade.java
+++ b/src/main/java/org/icgc/argo/program_service/services/ProgramServiceFacade.java
@@ -104,7 +104,34 @@ public class ProgramServiceFacade {
             program,
             (ProgramEntity pe) -> {
               initializeProgramInEgo(pe, admins);
-            });
+            },
+            null);
+    log.debug("Created {}", programEntity.getShortName());
+    return programConverter.programEntityToCreateProgramResponse(programEntity);
+  }
+
+  @Transactional
+  public CreateProgramResponse createProgram(CreateProgramRequest request, UUID dataCenterId) {
+    val errors = validationService.validateCreateProgramRequest(request);
+    if (errors.size() != 0) {
+      throw Status.INVALID_ARGUMENT
+          .augmentDescription(
+              format("Cannot create program: Program errors are [%s]", join(errors, ",")))
+          .asRuntimeException();
+    }
+
+    val program = request.getProgram();
+    val admins = request.getAdminsList();
+
+    // TODO: Refactor this, having a transactional side effect is no longer needed thanks to the
+    // facade
+    val programEntity =
+            programService.createWithSideEffect(
+                    program,
+                    (ProgramEntity pe) -> {
+                      initializeProgramInEgo(pe, admins);
+                    },
+                    dataCenterId);
     log.debug("Created {}", programEntity.getShortName());
     return programConverter.programEntityToCreateProgramResponse(programEntity);
   }

--- a/src/test/java/org/icgc/argo/program_service/grpc/ProgramServiceAuthorizationTest.java
+++ b/src/test/java/org/icgc/argo/program_service/grpc/ProgramServiceAuthorizationTest.java
@@ -136,8 +136,8 @@ public class ProgramServiceAuthorizationTest {
         .thenReturn(EgoPolicy.builder().id(associatePolicyId).build());
 
     val programService = mock(ProgramService.class);
-    when(programService.createProgram(any(), any())).thenReturn(entity());
-    when(programService.createWithSideEffect(any(), any(), any())).thenReturn(entity());
+    when(programService.createProgram(any())).thenReturn(entity());
+    when(programService.createWithSideEffect(any(), any())).thenReturn(entity());
     when(programService.getProgram(programName().getValue())).thenReturn(entity());
     when(programService.getProgram(programName().getValue(), false)).thenReturn(entity());
     when(programService.listPrograms()).thenReturn(List.of(entity(), entity2(), entity3()));

--- a/src/test/java/org/icgc/argo/program_service/grpc/ProgramServiceAuthorizationTest.java
+++ b/src/test/java/org/icgc/argo/program_service/grpc/ProgramServiceAuthorizationTest.java
@@ -136,8 +136,8 @@ public class ProgramServiceAuthorizationTest {
         .thenReturn(EgoPolicy.builder().id(associatePolicyId).build());
 
     val programService = mock(ProgramService.class);
-    when(programService.createProgram(any())).thenReturn(entity());
-    when(programService.createWithSideEffect(any(), any())).thenReturn(entity());
+    when(programService.createProgram(any(), any())).thenReturn(entity());
+    when(programService.createWithSideEffect(any(), any(), any())).thenReturn(entity());
     when(programService.getProgram(programName().getValue())).thenReturn(entity());
     when(programService.getProgram(programName().getValue(), false)).thenReturn(entity());
     when(programService.listPrograms()).thenReturn(List.of(entity(), entity2(), entity3()));


### PR DESCRIPTION
Enhanced Create Program Endpoint: Added Data Center ID Parameter and Improved Error Handling

In response to the requirements outlined in issue #413, this commit introduces several important enhancements to the Create Program endpoint:

**Data Center ID Parameter:** Programs can now be created with a designated Data Center ID. This change allows for improved data management and resource allocation, as programs can be associated with specific data centers.

**Error Handling for Invalid Data Center IDs**: The endpoint now returns an HTTP 400 error when an invalid Data Center ID is provided. The error response includes a descriptive message that explains why the request failed, helping users understand and address the issue.

The screenshot elaborates that we have added the data centre id in the request payload of create program api and validating it's presence against the data center table, the data center id which is present in the payload does not exist in the data centre table and thus it returns an error as Bad Request with HTTP Status 400 and displays a message as "Data CenterId not found"

<img width="1040" alt="Screenshot 2023-10-16 at 2 01 37 PM" src="https://github.com/icgc-argo/program-service/assets/121898125/e1755701-d947-46f9-b34e-e36394710c79">
