### PR TITLE
Changes related to "Modify Program DTO so all Program REST endpoints include some Data Center Information"

### DIFF
--- a/src/main/java/org/icgc/argo/program_service/controller/DataCenterController.java
+++ b/src/main/java/org/icgc/argo/program_service/controller/DataCenterController.java
@@ -37,9 +37,8 @@ public class DataCenterController {
           final String authorization,
       @PathVariable(value = "datacenter_short_name", required = true) String dataCenterShortName) {
     authorizationService.requireDCCAdmin(authorization);
-    val listProgramsResponse = serviceFacade.listProgramsByDataCenter(dataCenterShortName);
     return new ResponseEntity(
-        grpc2JsonConverter.prepareListProgramsResponse(listProgramsResponse), HttpStatus.OK);
+        serviceFacade.listProgramsByDataCenter(dataCenterShortName), HttpStatus.OK);
   }
 
   @PostMapping(value = "/datacenters")
@@ -63,5 +62,4 @@ public class DataCenterController {
         serviceFacade.updateDataCenter(dataCenterShortName, dataCenterRequestDTO);
     return new ResponseEntity(dataCenterEntity, HttpStatus.OK);
   }
-
 }

--- a/src/main/java/org/icgc/argo/program_service/controller/ProgramController.java
+++ b/src/main/java/org/icgc/argo/program_service/controller/ProgramController.java
@@ -98,8 +98,7 @@ public class ProgramController {
       authorizationService.requireProgramUser(shortName, authorization);
       GetProgramRequest request =
           GetProgramRequest.newBuilder().setShortName(StringValue.of(shortName)).build();
-      GetProgramResponse response = serviceFacade.getProgram(request);
-      programDetailsDTO = grpc2JsonConverter.prepareGetProgramResponse(response);
+      programDetailsDTO = serviceFacade.getProgramWithDataCenterDetails(request);
     } catch (StatusRuntimeException exception) {
       if (exception.getStatus().getCode().name().equalsIgnoreCase(HttpStatus.NOT_FOUND.name()))
         log.error("Exception thrown in getProgram: {}", exception.getMessage());
@@ -134,11 +133,10 @@ public class ProgramController {
   public ResponseEntity<List<ProgramDetailsDTO>> listPrograms(
       @Parameter(hidden = true) @RequestHeader(value = "Authorization", required = true)
           final String authorization) {
-    val listProgramsResponse =
-        serviceFacade.listPrograms(
-            p -> authorizationService.canRead(p.getShortName(), authorization));
     return new ResponseEntity(
-        grpc2JsonConverter.prepareListProgramsResponse(listProgramsResponse), HttpStatus.OK);
+        serviceFacade.listProgramsWithDataCenterDetails(
+            p -> authorizationService.canRead(p.getShortName(), authorization)),
+        HttpStatus.OK);
   }
 
   @PostMapping(value = "/users")

--- a/src/main/java/org/icgc/argo/program_service/controller/ProgramController.java
+++ b/src/main/java/org/icgc/argo/program_service/controller/ProgramController.java
@@ -43,7 +43,8 @@ public class ProgramController {
         grpc2JsonConverter.fromJson(
             grpc2JsonConverter.getJsonFromObject(createProgramRequestDTO),
             CreateProgramRequest.class);
-    CreateProgramResponse response = serviceFacade.createProgram(request);
+    CreateProgramResponse response =
+        serviceFacade.createProgram(request, createProgramRequestDTO.getDataCenterId());
     return new ResponseEntity(
         grpc2JsonConverter.prepareCreateProgramResponse(response), HttpStatus.CREATED);
   }

--- a/src/main/java/org/icgc/argo/program_service/converter/Grpc2JsonConverter.java
+++ b/src/main/java/org/icgc/argo/program_service/converter/Grpc2JsonConverter.java
@@ -121,6 +121,30 @@ public class Grpc2JsonConverter {
     return programDetailsDTO;
   }
 
+  public ProgramDetailsDTO prepareGetProgramResponse(ProgramDetails programDetails) {
+
+    ProgramDetailsDTO programDetailsDTO = new ProgramDetailsDTO();
+    try {
+      String responseJson = JsonFormat.printer().print(programDetails);
+      objectMapper =
+          JsonMapper.builder()
+              .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
+              .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+              .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+              .build();
+
+      programDetailsDTO = objectMapper.readValue(responseJson, ProgramDetailsDTO.class);
+
+    } catch (JsonMappingException e) {
+      e.printStackTrace();
+    } catch (JsonProcessingException e) {
+      e.printStackTrace();
+    } catch (InvalidProtocolBufferException e) {
+      e.printStackTrace();
+    }
+    return programDetailsDTO;
+  }
+
   public List<ProgramDetailsDTO> prepareListProgramsResponse(ListProgramsResponse response) {
 
     ProgramsResponseDTO programsResponseDTO = new ProgramsResponseDTO();

--- a/src/main/java/org/icgc/argo/program_service/converter/Grpc2JsonConverter.java
+++ b/src/main/java/org/icgc/argo/program_service/converter/Grpc2JsonConverter.java
@@ -13,6 +13,7 @@ import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.icgc.argo.program_service.model.dto.*;
+import org.icgc.argo.program_service.model.exceptions.ProgramRuntimeException;
 import org.icgc.argo.program_service.proto.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -33,8 +34,8 @@ public class Grpc2JsonConverter {
         | InvocationTargetException
         | NoSuchMethodException
         | SecurityException e) {
-      e.printStackTrace();
-      return null;
+      log.error(ExceptionUtils.getStackTrace(e));
+      throw new ProgramRuntimeException(e.getMessage());
     }
     JsonFormat.parser().ignoringUnknownFields().merge(json, builder);
     return (T) builder.build();
@@ -45,7 +46,7 @@ public class Grpc2JsonConverter {
       return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(response);
     } catch (Exception e) {
       log.error(ExceptionUtils.getStackTrace(e));
-      return null;
+      throw new ProgramRuntimeException(e.getMessage());
     }
   }
 
@@ -63,12 +64,9 @@ public class Grpc2JsonConverter {
       createProgramResponseDTO =
           objectMapper.readValue(responseJson, CreateProgramResponseDTO.class);
 
-    } catch (JsonMappingException e) {
-      e.printStackTrace();
-    } catch (JsonProcessingException e) {
-      e.printStackTrace();
-    } catch (InvalidProtocolBufferException e) {
-      e.printStackTrace();
+    } catch (JsonProcessingException | InvalidProtocolBufferException e) {
+      log.error(ExceptionUtils.getStackTrace(e));
+      throw new ProgramRuntimeException(e.getMessage());
     }
     return createProgramResponseDTO;
   }
@@ -87,12 +85,9 @@ public class Grpc2JsonConverter {
       updateProgramResponseDTO =
           objectMapper.readValue(responseJson, UpdateProgramResponseDTO.class);
 
-    } catch (JsonMappingException e) {
-      e.printStackTrace();
-    } catch (JsonProcessingException e) {
-      e.printStackTrace();
-    } catch (InvalidProtocolBufferException e) {
-      e.printStackTrace();
+    } catch (JsonProcessingException | InvalidProtocolBufferException e) {
+      log.error(ExceptionUtils.getStackTrace(e));
+      throw new ProgramRuntimeException(e.getMessage());
     }
     return updateProgramResponseDTO;
   }
@@ -111,12 +106,9 @@ public class Grpc2JsonConverter {
 
       programDetailsDTO = objectMapper.readValue(responseJson, ProgramDetailsDTO.class);
 
-    } catch (JsonMappingException e) {
-      e.printStackTrace();
-    } catch (JsonProcessingException e) {
-      e.printStackTrace();
-    } catch (InvalidProtocolBufferException e) {
-      e.printStackTrace();
+    } catch (JsonProcessingException | InvalidProtocolBufferException e) {
+      log.error(ExceptionUtils.getStackTrace(e));
+      throw new ProgramRuntimeException(e.getMessage());
     }
     return programDetailsDTO;
   }
@@ -124,24 +116,31 @@ public class Grpc2JsonConverter {
   public ProgramDetailsDTO prepareGetProgramResponse(ProgramDetails programDetails) {
 
     ProgramDetailsDTO programDetailsDTO = new ProgramDetailsDTO();
-    try {
-      String responseJson = JsonFormat.printer().print(programDetails);
-      objectMapper =
-          JsonMapper.builder()
-              .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
-              .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
-              .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-              .build();
-
-      programDetailsDTO = objectMapper.readValue(responseJson, ProgramDetailsDTO.class);
-
-    } catch (JsonMappingException e) {
-      e.printStackTrace();
-    } catch (JsonProcessingException e) {
-      e.printStackTrace();
-    } catch (InvalidProtocolBufferException e) {
-      e.printStackTrace();
-    }
+    ProgramsDTO programsDTO = new ProgramsDTO();
+    programsDTO.setCancerTypes(programDetails.getProgram().getCancerTypesList());
+    programsDTO.setCountries(programDetails.getProgram().getCountriesList());
+    programsDTO.setCommitmentDonors(programDetails.getProgram().getCommitmentDonors().getValue());
+    programsDTO.setDescription(programDetails.getProgram().getDescription().getValue());
+    programsDTO.setGenomicDonors(programDetails.getProgram().getGenomicDonors().getValue());
+    programsDTO.setInstitutions(programDetails.getProgram().getInstitutionsList());
+    programsDTO.setCountries(programDetails.getProgram().getCountriesList());
+    programsDTO.setName(programDetails.getProgram().getName().getValue());
+    programsDTO.setMembershipType(
+        programDetails.getProgram().getMembershipType().getValue().toString());
+    programsDTO.setPrimarySites(programDetails.getProgram().getPrimarySitesList());
+    programsDTO.setShortName(programDetails.getProgram().getShortName().getValue());
+    programsDTO.setSubmittedDonors(programDetails.getProgram().getSubmittedDonors().getValue());
+    programsDTO.setWebsite(programDetails.getProgram().getWebsite().getValue());
+    programDetailsDTO.setProgram(programsDTO);
+    LegacyDetailsDTO legacyDetailsDTO = new LegacyDetailsDTO();
+    legacyDetailsDTO.setLegacyShortName(programDetails.getLegacy().getLegacyShortName().getValue());
+    programDetailsDTO.setLegacy(legacyDetailsDTO);
+    MetadataDTO metadataDTO = new MetadataDTO();
+    metadataDTO.setCreatedAt(
+        String.valueOf(programDetails.getMetadata().getCreatedAt().getSeconds()));
+    metadataDTO.setUpdatedAt(
+        String.valueOf(programDetails.getMetadata().getUpdatedAt().getSeconds()));
+    programDetailsDTO.setMetadata(metadataDTO);
     return programDetailsDTO;
   }
 
@@ -159,12 +158,9 @@ public class Grpc2JsonConverter {
 
       programsResponseDTO = objectMapper.readValue(responseJson, ProgramsResponseDTO.class);
 
-    } catch (JsonMappingException e) {
-      e.printStackTrace();
-    } catch (JsonProcessingException e) {
-      e.printStackTrace();
-    } catch (InvalidProtocolBufferException e) {
-      e.printStackTrace();
+    } catch (JsonProcessingException | InvalidProtocolBufferException e) {
+      log.error(ExceptionUtils.getStackTrace(e));
+      throw new ProgramRuntimeException(e.getMessage());
     }
     return programsResponseDTO.getPrograms();
   }
@@ -183,12 +179,9 @@ public class Grpc2JsonConverter {
 
       inviteUserResponseDTO = objectMapper.readValue(responseJson, InviteUserResponseDTO.class);
 
-    } catch (JsonMappingException e) {
-      e.printStackTrace();
-    } catch (JsonProcessingException e) {
-      e.printStackTrace();
-    } catch (InvalidProtocolBufferException e) {
-      e.printStackTrace();
+    } catch (JsonProcessingException | InvalidProtocolBufferException e) {
+      log.error(ExceptionUtils.getStackTrace(e));
+      throw new ProgramRuntimeException(e.getMessage());
     }
     return inviteUserResponseDTO;
   }
@@ -207,12 +200,9 @@ public class Grpc2JsonConverter {
 
       joinProgramResponseDTO = objectMapper.readValue(responseJson, JoinProgramResponseDTO.class);
 
-    } catch (JsonMappingException e) {
-      e.printStackTrace();
-    } catch (JsonProcessingException e) {
-      e.printStackTrace();
-    } catch (InvalidProtocolBufferException e) {
-      e.printStackTrace();
+    } catch (JsonProcessingException | InvalidProtocolBufferException e) {
+      log.error(ExceptionUtils.getStackTrace(e));
+      throw new ProgramRuntimeException(e.getMessage());
     }
     return joinProgramResponseDTO;
   }
@@ -231,12 +221,9 @@ public class Grpc2JsonConverter {
 
       listUsersResponseDTO = objectMapper.readValue(responseJson, ListUsersResponseDTO.class);
 
-    } catch (JsonMappingException e) {
-      e.printStackTrace();
-    } catch (JsonProcessingException e) {
-      e.printStackTrace();
-    } catch (InvalidProtocolBufferException e) {
-      e.printStackTrace();
+    } catch (JsonProcessingException | InvalidProtocolBufferException e) {
+      log.error(ExceptionUtils.getStackTrace(e));
+      throw new ProgramRuntimeException(e.getMessage());
     }
     return listUsersResponseDTO;
   }
@@ -255,12 +242,9 @@ public class Grpc2JsonConverter {
 
       removeUserResponseDTO = objectMapper.readValue(responseJson, RemoveUserResponseDTO.class);
 
-    } catch (JsonMappingException e) {
-      e.printStackTrace();
-    } catch (JsonProcessingException e) {
-      e.printStackTrace();
-    } catch (InvalidProtocolBufferException e) {
-      e.printStackTrace();
+    } catch (JsonProcessingException | InvalidProtocolBufferException e) {
+      log.error(ExceptionUtils.getStackTrace(e));
+      throw new ProgramRuntimeException(e.getMessage());
     }
     return removeUserResponseDTO;
   }
@@ -279,12 +263,9 @@ public class Grpc2JsonConverter {
 
       joinProgramInviteDTO = objectMapper.readValue(responseJson, JoinProgramInviteDTO.class);
 
-    } catch (JsonMappingException e) {
-      e.printStackTrace();
-    } catch (JsonProcessingException e) {
-      e.printStackTrace();
-    } catch (InvalidProtocolBufferException e) {
-      e.printStackTrace();
+    } catch (JsonProcessingException | InvalidProtocolBufferException e) {
+      log.error(ExceptionUtils.getStackTrace(e));
+      throw new ProgramRuntimeException(e.getMessage());
     }
     return joinProgramInviteDTO;
   }
@@ -303,12 +284,9 @@ public class Grpc2JsonConverter {
 
       listCancersResponseDTO = objectMapper.readValue(responseJson, ListCancersResponseDTO.class);
 
-    } catch (JsonMappingException e) {
-      e.printStackTrace();
-    } catch (JsonProcessingException e) {
-      e.printStackTrace();
-    } catch (InvalidProtocolBufferException e) {
-      e.printStackTrace();
+    } catch (JsonProcessingException | InvalidProtocolBufferException e) {
+      log.error(ExceptionUtils.getStackTrace(e));
+      throw new ProgramRuntimeException(e.getMessage());
     }
     return listCancersResponseDTO;
   }
@@ -329,12 +307,9 @@ public class Grpc2JsonConverter {
       listPrimarySitesResponseDTO =
           objectMapper.readValue(responseJson, ListPrimarySitesResponseDTO.class);
 
-    } catch (JsonMappingException e) {
-      e.printStackTrace();
-    } catch (JsonProcessingException e) {
-      e.printStackTrace();
-    } catch (InvalidProtocolBufferException e) {
-      e.printStackTrace();
+    } catch (JsonProcessingException | InvalidProtocolBufferException e) {
+      log.error(ExceptionUtils.getStackTrace(e));
+      throw new ProgramRuntimeException(e.getMessage());
     }
     return listPrimarySitesResponseDTO;
   }
@@ -354,12 +329,9 @@ public class Grpc2JsonConverter {
       listCountriesResponseDTO =
           objectMapper.readValue(responseJson, ListCountriesResponseDTO.class);
 
-    } catch (JsonMappingException e) {
-      e.printStackTrace();
-    } catch (JsonProcessingException e) {
-      e.printStackTrace();
-    } catch (InvalidProtocolBufferException e) {
-      e.printStackTrace();
+    } catch (JsonProcessingException | InvalidProtocolBufferException e) {
+      log.error(ExceptionUtils.getStackTrace(e));
+      throw new ProgramRuntimeException(e.getMessage());
     }
     return listCountriesResponseDTO;
   }
@@ -378,12 +350,9 @@ public class Grpc2JsonConverter {
 
       listRegionsResponseDTO = objectMapper.readValue(responseJson, ListRegionsResponseDTO.class);
 
-    } catch (JsonMappingException e) {
-      e.printStackTrace();
-    } catch (JsonProcessingException e) {
-      e.printStackTrace();
-    } catch (InvalidProtocolBufferException e) {
-      e.printStackTrace();
+    } catch (JsonProcessingException | InvalidProtocolBufferException e) {
+      log.error(ExceptionUtils.getStackTrace(e));
+      throw new ProgramRuntimeException(e.getMessage());
     }
     return listRegionsResponseDTO;
   }
@@ -404,12 +373,9 @@ public class Grpc2JsonConverter {
       listInstitutionsResponseDTO =
           objectMapper.readValue(responseJson, ListInstitutionsResponseDTO.class);
 
-    } catch (JsonMappingException e) {
-      e.printStackTrace();
-    } catch (JsonProcessingException e) {
-      e.printStackTrace();
-    } catch (InvalidProtocolBufferException e) {
-      e.printStackTrace();
+    } catch (JsonProcessingException | InvalidProtocolBufferException e) {
+      log.error(ExceptionUtils.getStackTrace(e));
+      throw new ProgramRuntimeException(e.getMessage());
     }
     return listInstitutionsResponseDTO;
   }
@@ -430,12 +396,9 @@ public class Grpc2JsonConverter {
       addInstitutionsResponseDTO =
           objectMapper.readValue(responseJson, AddInstitutionsResponseDTO.class);
 
-    } catch (JsonMappingException e) {
-      e.printStackTrace();
-    } catch (JsonProcessingException e) {
-      e.printStackTrace();
-    } catch (InvalidProtocolBufferException e) {
-      e.printStackTrace();
+    } catch (JsonProcessingException | InvalidProtocolBufferException e) {
+      log.error(ExceptionUtils.getStackTrace(e));
+      throw new ProgramRuntimeException(e.getMessage());
     }
     return addInstitutionsResponseDTO;
   }

--- a/src/main/java/org/icgc/argo/program_service/exception/ExceptionHandlers.java
+++ b/src/main/java/org/icgc/argo/program_service/exception/ExceptionHandlers.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
+import org.icgc.argo.program_service.model.exceptions.BadRequestException;
 import org.icgc.argo.program_service.model.exceptions.ForbiddenException;
 import org.icgc.argo.program_service.model.exceptions.NotFoundException;
 import org.icgc.argo.program_service.model.exceptions.UnauthorizedException;
@@ -62,5 +63,20 @@ public class ExceptionHandlers {
             "error", NOT_FOUND.getReasonPhrase()),
         new HttpHeaders(),
         NOT_FOUND);
+  }
+
+  @ExceptionHandler(BadRequestException.class)
+  public ResponseEntity<Object> handleForbiddenException(
+      HttpServletRequest req, BadRequestException ex) {
+    val message = ex.getMessage();
+    log.error(message);
+    return new ResponseEntity<Object>(
+        Map.of(
+            "message", ex.getMessage(),
+            "timestamp", new Date(),
+            "path", req.getServletPath(),
+            "error", BAD_REQUEST.getReasonPhrase()),
+        new HttpHeaders(),
+        BAD_REQUEST);
   }
 }

--- a/src/main/java/org/icgc/argo/program_service/exception/ExceptionHandlers.java
+++ b/src/main/java/org/icgc/argo/program_service/exception/ExceptionHandlers.java
@@ -7,10 +7,7 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
-import org.icgc.argo.program_service.model.exceptions.BadRequestException;
-import org.icgc.argo.program_service.model.exceptions.ForbiddenException;
-import org.icgc.argo.program_service.model.exceptions.NotFoundException;
-import org.icgc.argo.program_service.model.exceptions.UnauthorizedException;
+import org.icgc.argo.program_service.model.exceptions.*;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -78,5 +75,20 @@ public class ExceptionHandlers {
             "error", BAD_REQUEST.getReasonPhrase()),
         new HttpHeaders(),
         BAD_REQUEST);
+  }
+
+  @ExceptionHandler(ProgramRuntimeException.class)
+  public ResponseEntity<Object> handleProgramRuntimeException(
+      HttpServletRequest req, ProgramRuntimeException ex) {
+    val message = ex.getMessage();
+    log.error(message);
+    return new ResponseEntity<Object>(
+        Map.of(
+            "message", ex.getMessage(),
+            "timestamp", new Date(),
+            "path", req.getServletPath(),
+            "error", INTERNAL_SERVER_ERROR.getReasonPhrase()),
+        new HttpHeaders(),
+        INTERNAL_SERVER_ERROR);
   }
 }

--- a/src/main/java/org/icgc/argo/program_service/exception/ExceptionHandlers.java
+++ b/src/main/java/org/icgc/argo/program_service/exception/ExceptionHandlers.java
@@ -77,6 +77,21 @@ public class ExceptionHandlers {
         BAD_REQUEST);
   }
 
+  @ExceptionHandler(RecordNotFoundException.class)
+  public ResponseEntity<Object> handleRecordNotFoundException(
+      HttpServletRequest req, RecordNotFoundException ex) {
+    val message = ex.getMessage();
+    log.error(message);
+    return new ResponseEntity<Object>(
+        Map.of(
+            "message", ex.getMessage(),
+            "timestamp", new Date(),
+            "path", req.getServletPath(),
+            "error", BAD_REQUEST.getReasonPhrase()),
+        new HttpHeaders(),
+        BAD_REQUEST);
+  }
+
   @ExceptionHandler(ProgramRuntimeException.class)
   public ResponseEntity<Object> handleProgramRuntimeException(
       HttpServletRequest req, ProgramRuntimeException ex) {

--- a/src/main/java/org/icgc/argo/program_service/model/dto/CreateProgramRequestDTO.java
+++ b/src/main/java/org/icgc/argo/program_service/model/dto/CreateProgramRequestDTO.java
@@ -1,6 +1,7 @@
 package org.icgc.argo.program_service.model.dto;
 
 import java.util.List;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -13,5 +14,6 @@ import lombok.NoArgsConstructor;
 public class CreateProgramRequestDTO {
 
   private Program program;
+  private UUID dataCenterId;
   List<UserDTO> admins;
 }

--- a/src/main/java/org/icgc/argo/program_service/model/dto/DataCenterDetailsDTO.java
+++ b/src/main/java/org/icgc/argo/program_service/model/dto/DataCenterDetailsDTO.java
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2020 The Ontario Institute for Cancer Research. All rights reserved
+ * Copyright (c) 2023 The Ontario Institute for Cancer Research. All rights reserved
+
  *
  * This program and the accompanying materials are made available under the terms of the GNU Affero General Public License v3.0.
  * You should have received a copy of the GNU Affero General Public License along with

--- a/src/main/java/org/icgc/argo/program_service/model/dto/DataCenterDetailsDTO.java
+++ b/src/main/java/org/icgc/argo/program_service/model/dto/DataCenterDetailsDTO.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of the GNU Affero General Public License v3.0.
+ * You should have received a copy of the GNU Affero General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ */
+
+package org.icgc.argo.program_service.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class DataCenterDetailsDTO {
+
+  private String id;
+
+  private String shortName;
+
+  private String name;
+
+  private String uiUrl;
+
+  private String gatewayUrl;
+}

--- a/src/main/java/org/icgc/argo/program_service/model/dto/ProgramsDTO.java
+++ b/src/main/java/org/icgc/argo/program_service/model/dto/ProgramsDTO.java
@@ -33,4 +33,6 @@ public class ProgramsDTO {
   private List<String> cancerTypes;
 
   private List<String> primarySites;
+
+  private DataCenterDetailsDTO dataCenter;
 }

--- a/src/main/java/org/icgc/argo/program_service/model/dto/ProgramsDTO.java
+++ b/src/main/java/org/icgc/argo/program_service/model/dto/ProgramsDTO.java
@@ -26,6 +26,8 @@ public class ProgramsDTO {
 
   private int genomicDonors;
 
+  private String membershipType;
+
   private List<String> institutions;
 
   private List<String> countries;

--- a/src/main/java/org/icgc/argo/program_service/model/exceptions/BadRequestException.java
+++ b/src/main/java/org/icgc/argo/program_service/model/exceptions/BadRequestException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of the GNU Affero General Public License v3.0.
+ * You should have received a copy of the GNU Affero General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ */
+
+package org.icgc.argo.program_service.model.exceptions;
+
+import lombok.NonNull;
+
+public class BadRequestException extends RuntimeException {
+
+  public BadRequestException(@NonNull String message) {
+    super(message);
+  }
+
+  public static void checkNotFound(
+      boolean expression, @NonNull String message, @NonNull Object... args) {
+    if (!expression) {
+      throw new BadRequestException(String.format(message, args));
+    }
+  }
+}

--- a/src/main/java/org/icgc/argo/program_service/model/exceptions/ProgramRuntimeException.java
+++ b/src/main/java/org/icgc/argo/program_service/model/exceptions/ProgramRuntimeException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of the GNU Affero General Public License v3.0.
+ * You should have received a copy of the GNU Affero General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ */
+
+package org.icgc.argo.program_service.model.exceptions;
+
+import lombok.NonNull;
+
+public class ProgramRuntimeException extends RuntimeException {
+
+  public ProgramRuntimeException(@NonNull String message) {
+    super(message);
+  }
+
+  public static void checkNotFound(
+      boolean expression, @NonNull String message, @NonNull Object... args) {
+    if (!expression) {
+      throw new ProgramRuntimeException(String.format(message, args));
+    }
+  }
+}

--- a/src/main/java/org/icgc/argo/program_service/services/ProgramService.java
+++ b/src/main/java/org/icgc/argo/program_service/services/ProgramService.java
@@ -67,6 +67,7 @@ public class ProgramService {
 
   /** Dependencies */
   private final ProgramRepository programRepository;
+
   private final DataCenterRepository dataCenterRepository;
   private final CancerRepository cancerRepository;
   private final PrimarySiteRepository primarySiteRepository;
@@ -430,6 +431,11 @@ public class ProgramService {
     return List.copyOf(dataCenters);
   }
 
+  public DataCenterEntity getDataCenterDetails(UUID dataCenterId) {
+    val dataCenterEntity = dataCenterRepository.findById(dataCenterId);
+    return dataCenterEntity.get();
+  }
+
   public DataCenterEntity createDataCenter(DataCenterRequestDTO dataCenterRequestDTO) {
     val dataCenterEntity = dataCenterConverter.dataCenterToDataCenterEntity(dataCenterRequestDTO);
     val d = dataCenterRepository.save(dataCenterEntity);
@@ -519,5 +525,4 @@ public class ProgramService {
     val id = program.getId();
     return r -> r.getProgram().getId().equals(id) && regions.contains(r.getRegion());
   }
-
 }

--- a/src/main/java/org/icgc/argo/program_service/services/ProgramServiceFacade.java
+++ b/src/main/java/org/icgc/argo/program_service/services/ProgramServiceFacade.java
@@ -108,34 +108,7 @@ public class ProgramServiceFacade {
             program,
             (ProgramEntity pe) -> {
               initializeProgramInEgo(pe, admins);
-            },
-            null);
-    log.debug("Created {}", programEntity.getShortName());
-    return programConverter.programEntityToCreateProgramResponse(programEntity);
-  }
-
-  @Transactional
-  public CreateProgramResponse createProgram(CreateProgramRequest request, UUID dataCenterId) {
-    val errors = validationService.validateCreateProgramRequest(request);
-    if (errors.size() != 0) {
-      throw Status.INVALID_ARGUMENT
-          .augmentDescription(
-              format("Cannot create program: Program errors are [%s]", join(errors, ",")))
-          .asRuntimeException();
-    }
-
-    val program = request.getProgram();
-    val admins = request.getAdminsList();
-
-    // TODO: Refactor this, having a transactional side effect is no longer needed thanks to the
-    // facade
-    val programEntity =
-        programService.createWithSideEffect(
-            program,
-            (ProgramEntity pe) -> {
-              initializeProgramInEgo(pe, admins);
-            },
-            dataCenterId);
+            });
     log.debug("Created {}", programEntity.getShortName());
     return programConverter.programEntityToCreateProgramResponse(programEntity);
   }

--- a/src/main/java/org/icgc/argo/program_service/services/ProgramServiceFacade.java
+++ b/src/main/java/org/icgc/argo/program_service/services/ProgramServiceFacade.java
@@ -104,7 +104,34 @@ public class ProgramServiceFacade {
             program,
             (ProgramEntity pe) -> {
               initializeProgramInEgo(pe, admins);
-            });
+            },
+            null);
+    log.debug("Created {}", programEntity.getShortName());
+    return programConverter.programEntityToCreateProgramResponse(programEntity);
+  }
+
+  @Transactional
+  public CreateProgramResponse createProgram(CreateProgramRequest request, UUID dataCenterId) {
+    val errors = validationService.validateCreateProgramRequest(request);
+    if (errors.size() != 0) {
+      throw Status.INVALID_ARGUMENT
+          .augmentDescription(
+              format("Cannot create program: Program errors are [%s]", join(errors, ",")))
+          .asRuntimeException();
+    }
+
+    val program = request.getProgram();
+    val admins = request.getAdminsList();
+
+    // TODO: Refactor this, having a transactional side effect is no longer needed thanks to the
+    // facade
+    val programEntity =
+            programService.createWithSideEffect(
+                    program,
+                    (ProgramEntity pe) -> {
+                      initializeProgramInEgo(pe, admins);
+                    },
+                    dataCenterId);
     log.debug("Created {}", programEntity.getShortName());
     return programConverter.programEntityToCreateProgramResponse(programEntity);
   }

--- a/src/test/java/org/icgc/argo/program_service/grpc/ProgramServiceAuthorizationTest.java
+++ b/src/test/java/org/icgc/argo/program_service/grpc/ProgramServiceAuthorizationTest.java
@@ -51,6 +51,7 @@ import lombok.AllArgsConstructor;
 import lombok.val;
 import org.icgc.argo.program_service.converter.CommonConverter;
 import org.icgc.argo.program_service.converter.DataCenterConverter;
+import org.icgc.argo.program_service.converter.Grpc2JsonConverter;
 import org.icgc.argo.program_service.converter.ProgramConverter;
 import org.icgc.argo.program_service.grpc.interceptor.EgoAuthInterceptor;
 import org.icgc.argo.program_service.grpc.interceptor.ExceptionInterceptor;
@@ -119,6 +120,8 @@ public class ProgramServiceAuthorizationTest {
 
     val egoSecurity = new EgoSecurity(publicKey);
 
+    val grpc2JsonConverter = mock(Grpc2JsonConverter.class);
+
     val mockEgoService = mock(EgoService.class);
 
     val adminGroupId = UUID.randomUUID();
@@ -151,6 +154,7 @@ public class ProgramServiceAuthorizationTest {
             mockEgoService,
             invitationService,
             programConverter,
+            grpc2JsonConverter,
             dataCenterConverter,
             commonConverter,
             v);

--- a/src/test/java/org/icgc/argo/program_service/grpc/ProgramServiceAuthorizationTest.java
+++ b/src/test/java/org/icgc/argo/program_service/grpc/ProgramServiceAuthorizationTest.java
@@ -139,8 +139,8 @@ public class ProgramServiceAuthorizationTest {
         .thenReturn(EgoPolicy.builder().id(associatePolicyId).build());
 
     val programService = mock(ProgramService.class);
-    when(programService.createProgram(any(), any())).thenReturn(entity());
-    when(programService.createWithSideEffect(any(), any(), any())).thenReturn(entity());
+    when(programService.createProgram(any())).thenReturn(entity());
+    when(programService.createWithSideEffect(any(), any())).thenReturn(entity());
     when(programService.getProgram(programName().getValue())).thenReturn(entity());
     when(programService.getProgram(programName().getValue(), false)).thenReturn(entity());
     when(programService.listPrograms()).thenReturn(List.of(entity(), entity2(), entity3()));

--- a/src/test/java/org/icgc/argo/program_service/grpc/ProgramServiceAuthorizationTest.java
+++ b/src/test/java/org/icgc/argo/program_service/grpc/ProgramServiceAuthorizationTest.java
@@ -136,8 +136,8 @@ public class ProgramServiceAuthorizationTest {
         .thenReturn(EgoPolicy.builder().id(associatePolicyId).build());
 
     val programService = mock(ProgramService.class);
-    when(programService.createProgram(any())).thenReturn(entity());
-    when(programService.createWithSideEffect(any(), any())).thenReturn(entity());
+    when(programService.createProgram(any(), any())).thenReturn(entity());
+    when(programService.createWithSideEffect(any(), any(), any())).thenReturn(entity());
     when(programService.getProgram(programName().getValue())).thenReturn(entity());
     when(programService.getProgram(programName().getValue(), false)).thenReturn(entity());
     when(programService.listPrograms()).thenReturn(List.of(entity(), entity2(), entity3()));

--- a/src/test/java/org/icgc/argo/program_service/grpc/ProgramServiceImplTest.java
+++ b/src/test/java/org/icgc/argo/program_service/grpc/ProgramServiceImplTest.java
@@ -40,6 +40,7 @@ import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.icgc.argo.program_service.converter.CommonConverter;
 import org.icgc.argo.program_service.converter.DataCenterConverter;
+import org.icgc.argo.program_service.converter.Grpc2JsonConverter;
 import org.icgc.argo.program_service.converter.ProgramConverter;
 import org.icgc.argo.program_service.model.entity.JoinProgramInviteEntity;
 import org.icgc.argo.program_service.model.entity.ProgramEntity;
@@ -76,6 +77,7 @@ class ProgramServiceImplTest {
   ProgramService programService = mock(ProgramService.class);
   InvitationService invitationService = mock(InvitationService.class);
   EgoService egoService = mock(EgoService.class);
+  Grpc2JsonConverter grpc2JsonConvertor = mock(Grpc2JsonConverter.class);
   AuthorizationService authorizationService = mock(AuthorizationService.class);
   ValidationService validationService = mock(ValidationService.class);
   ProgramServiceFacade facade =
@@ -84,6 +86,7 @@ class ProgramServiceImplTest {
           egoService,
           invitationService,
           programConverter,
+          grpc2JsonConvertor,
           dataCenterConverter,
           CommonConverter.INSTANCE,
           validationService);
@@ -514,6 +517,7 @@ class ProgramServiceImplTest {
       Map<String, JoinProgramInviteEntity> egoInvitations) {
     ProgramService programService = mock(ProgramService.class);
     InvitationService invitationService = mock(InvitationService.class);
+    Grpc2JsonConverter grpc2JsonConvertor = mock(Grpc2JsonConverter.class);
     EgoService egoService = mock(EgoService.class);
     AuthorizationService authorizationService = mock(AuthorizationService.class);
     ValidationService validationService = mock(ValidationService.class);
@@ -531,6 +535,7 @@ class ProgramServiceImplTest {
             egoService,
             invitationService,
             programConverter,
+            grpc2JsonConvertor,
             dataCenterConverter,
             CommonConverter.INSTANCE,
             validationService);


### PR DESCRIPTION
In this ticket #420,we have modified and added more functionality to the Program Service to serve as a Data Center Registry for ARGO's Regional Data Processing Centers (RDPCs). Each program now belongs to a single Data Center, and relevant Data Center details are included in the Program entity. These changes impact five endpoints: CreateProgram, UpdateProgram, ListPrograms, GetProgram, and List Data Center Programs.

The screenshot below depicts that "List Data Center Programs" now includes a list of programs where each program should contain the specified information.
![List Data Center Programs](https://github.com/icgc-argo/program-service/assets/121898125/618be4ed-93b1-419d-abb9-2e3abf8da7d8)
