### PR TITLE
GET joinProgramInvite does not require authorization

### DIFF
--- a/src/main/java/org/icgc/argo/program_service/controller/ProgramController.java
+++ b/src/main/java/org/icgc/argo/program_service/controller/ProgramController.java
@@ -234,7 +234,7 @@ public class ProgramController {
 
   @GetMapping(value = "/joinProgramInvite/{invite_id}")
   public ResponseEntity<GetJoinProgramInviteResponseDTO> getJoinProgramInvite(
-      @Parameter(hidden = true) @RequestHeader(value = "Authorization", required = true)
+      @Parameter(hidden = true) @RequestHeader(value = "Authorization", required = false)
           final String authorization,
       @PathVariable(value = "invite_id", required = true) String inviteId) {
     val invitation = serviceFacade.getInvitationById(UUID.fromString(inviteId));


### PR DESCRIPTION
Removes the requirement for an `Authorization` header in the `GET /joinProgramInvite` request. This will allow a user that is not logged in and is accepting a join program invite to see the details of their invite.