### PR TITLE
Fix related to UpdateProgramApi

### DIFF
--- a/src/main/java/org/icgc/argo/program_service/controller/ProgramController.java
+++ b/src/main/java/org/icgc/argo/program_service/controller/ProgramController.java
@@ -76,7 +76,7 @@ public class ProgramController {
     try {
       request =
               grpc2JsonConverter.prepareUpdateProgramRequest(updateProgramRequestDTO);
-      response = serviceFacade.updateProgram(request);
+      response = serviceFacade.updateProgramWithDataCenter(request, updateProgramRequestDTO.getProgram().getDataCenter());
     } catch (NotFoundException | NoSuchElementException e) {
       log.error("Exception thrown in updateProgram: {}", e.getMessage());
       return new ResponseEntity(e.getMessage(), HttpStatus.BAD_REQUEST);

--- a/src/main/java/org/icgc/argo/program_service/controller/ProgramController.java
+++ b/src/main/java/org/icgc/argo/program_service/controller/ProgramController.java
@@ -75,11 +75,9 @@ public class ProgramController {
     UpdateProgramResponse response;
     try {
       request =
-          grpc2JsonConverter.fromJson(
-              grpc2JsonConverter.getJsonFromObject(updateProgramRequestDTO),
-              UpdateProgramRequest.class);
+              grpc2JsonConverter.prepareUpdateProgramRequest(updateProgramRequestDTO);
       response = serviceFacade.updateProgram(request);
-    } catch (NotFoundException | NoSuchElementException | IOException e) {
+    } catch (NotFoundException | NoSuchElementException e) {
       log.error("Exception thrown in updateProgram: {}", e.getMessage());
       return new ResponseEntity(e.getMessage(), HttpStatus.BAD_REQUEST);
     }

--- a/src/main/java/org/icgc/argo/program_service/controller/ProgramController.java
+++ b/src/main/java/org/icgc/argo/program_service/controller/ProgramController.java
@@ -3,10 +3,6 @@ package org.icgc.argo.program_service.controller;
 import com.google.protobuf.StringValue;
 import io.grpc.StatusRuntimeException;
 import io.swagger.v3.oas.annotations.Parameter;
-import java.io.IOException;
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang.exception.ExceptionUtils;
@@ -23,6 +19,10 @@ import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import java.io.IOException;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
 
 @Slf4j
 @RestController
@@ -71,12 +71,9 @@ public class ProgramController {
           final String authorization,
       @RequestBody UpdateProgramRequestDTO updateProgramRequestDTO) {
     authorizationService.requireDCCAdmin(authorization);
-    UpdateProgramRequest request;
     UpdateProgramResponse response;
     try {
-      request =
-              grpc2JsonConverter.prepareUpdateProgramRequest(updateProgramRequestDTO);
-      response = serviceFacade.updateProgramWithDataCenter(request, updateProgramRequestDTO.getProgram().getDataCenter());
+      response = serviceFacade.updateProgramWithDataCenter(updateProgramRequestDTO);
     } catch (NotFoundException | NoSuchElementException e) {
       log.error("Exception thrown in updateProgram: {}", e.getMessage());
       return new ResponseEntity(e.getMessage(), HttpStatus.BAD_REQUEST);

--- a/src/main/java/org/icgc/argo/program_service/converter/Grpc2JsonConverter.java
+++ b/src/main/java/org/icgc/argo/program_service/converter/Grpc2JsonConverter.java
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.protobuf.AbstractMessage.Builder;
+import com.google.protobuf.Int32Value;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
+import com.google.protobuf.StringValue;
 import com.google.protobuf.util.JsonFormat;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -15,6 +17,7 @@ import org.apache.commons.lang.exception.ExceptionUtils;
 import org.icgc.argo.program_service.model.dto.*;
 import org.icgc.argo.program_service.model.exceptions.ProgramRuntimeException;
 import org.icgc.argo.program_service.proto.*;
+import org.icgc.argo.program_service.proto.Program;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -49,7 +52,30 @@ public class Grpc2JsonConverter {
       throw new ProgramRuntimeException(e.getMessage());
     }
   }
+  public UpdateProgramRequest prepareUpdateProgramRequest (UpdateProgramRequestDTO updateProgramRequestDTO) {
 
+    Program program = Program.newBuilder()
+            .addAllCancerTypes(updateProgramRequestDTO.getProgram().getCancerTypes())
+            .setCommitmentDonors(Int32Value.of(updateProgramRequestDTO.getProgram().getCommitmentDonors()))
+            .addAllCountries(updateProgramRequestDTO.getProgram().getCountries())
+            .setDescription(StringValue.of(updateProgramRequestDTO.getProgram().getDescription()))
+            .setGenomicDonors(Int32Value.of(updateProgramRequestDTO.getProgram().getGenomicDonors()))
+            .addAllInstitutions(updateProgramRequestDTO.getProgram().getInstitutions())
+            .setName(StringValue.of(updateProgramRequestDTO.getProgram().getName()))
+            .addAllPrimarySites(updateProgramRequestDTO.getProgram().getPrimarySites())
+            .setMembershipType(MembershipTypeValue.newBuilder().setValue(updateProgramRequestDTO.getProgram().getMembershipType()))
+            .setShortName(StringValue.of(updateProgramRequestDTO.getProgram().getShortName()))
+            .setSubmittedDonors(Int32Value.of(updateProgramRequestDTO.getProgram().getSubmittedDonors()))
+            .setWebsite(StringValue.of(updateProgramRequestDTO.getProgram().getWebsite()))
+            .build();
+
+    UpdateProgramRequest updateProgramRequest =
+            UpdateProgramRequest.newBuilder()
+                    .setProgram(program)
+                    .build();
+
+    return updateProgramRequest;
+  }
   public CreateProgramResponseDTO prepareCreateProgramResponse(CreateProgramResponse response) {
 
     CreateProgramResponseDTO createProgramResponseDTO = new CreateProgramResponseDTO();

--- a/src/main/java/org/icgc/argo/program_service/converter/Grpc2JsonConverter.java
+++ b/src/main/java/org/icgc/argo/program_service/converter/Grpc2JsonConverter.java
@@ -4,10 +4,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.protobuf.AbstractMessage.Builder;
-import com.google.protobuf.Int32Value;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
-import com.google.protobuf.StringValue;
 import com.google.protobuf.util.JsonFormat;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -17,7 +15,6 @@ import org.apache.commons.lang.exception.ExceptionUtils;
 import org.icgc.argo.program_service.model.dto.*;
 import org.icgc.argo.program_service.model.exceptions.ProgramRuntimeException;
 import org.icgc.argo.program_service.proto.*;
-import org.icgc.argo.program_service.proto.Program;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -51,30 +48,6 @@ public class Grpc2JsonConverter {
       log.error(ExceptionUtils.getStackTrace(e));
       throw new ProgramRuntimeException(e.getMessage());
     }
-  }
-  public UpdateProgramRequest prepareUpdateProgramRequest (UpdateProgramRequestDTO updateProgramRequestDTO) {
-
-    Program program = Program.newBuilder()
-            .addAllCancerTypes(updateProgramRequestDTO.getProgram().getCancerTypes())
-            .setCommitmentDonors(Int32Value.of(updateProgramRequestDTO.getProgram().getCommitmentDonors()))
-            .addAllCountries(updateProgramRequestDTO.getProgram().getCountries())
-            .setDescription(StringValue.of(updateProgramRequestDTO.getProgram().getDescription()))
-            .setGenomicDonors(Int32Value.of(updateProgramRequestDTO.getProgram().getGenomicDonors()))
-            .addAllInstitutions(updateProgramRequestDTO.getProgram().getInstitutions())
-            .setName(StringValue.of(updateProgramRequestDTO.getProgram().getName()))
-            .addAllPrimarySites(updateProgramRequestDTO.getProgram().getPrimarySites())
-            .setMembershipType(MembershipTypeValue.newBuilder().setValue(updateProgramRequestDTO.getProgram().getMembershipType()))
-            .setShortName(StringValue.of(updateProgramRequestDTO.getProgram().getShortName()))
-            .setSubmittedDonors(Int32Value.of(updateProgramRequestDTO.getProgram().getSubmittedDonors()))
-            .setWebsite(StringValue.of(updateProgramRequestDTO.getProgram().getWebsite()))
-            .build();
-
-    UpdateProgramRequest updateProgramRequest =
-            UpdateProgramRequest.newBuilder()
-                    .setProgram(program)
-                    .build();
-
-    return updateProgramRequest;
   }
   public CreateProgramResponseDTO prepareCreateProgramResponse(CreateProgramResponse response) {
 

--- a/src/main/java/org/icgc/argo/program_service/converter/ProgramConverter.java
+++ b/src/main/java/org/icgc/argo/program_service/converter/ProgramConverter.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 import java.util.UUID;
 import lombok.NonNull;
 import lombok.val;
+import org.icgc.argo.program_service.model.dto.ProgramsDTO;
 import org.icgc.argo.program_service.model.entity.*;
 import org.icgc.argo.program_service.proto.*;
 import org.icgc.argo.program_service.services.ego.model.entity.EgoUser;
@@ -42,6 +43,22 @@ import org.mapstruct.MappingTarget;
     uses = {CommonConverter.class})
 public interface ProgramConverter {
   ProgramConverter INSTANCE = new ProgramConverterImpl(CommonConverter.INSTANCE);
+
+  @Mapping(target = "id", ignore = true)
+  @Mapping(target = "updatedAt", ignore = true)
+  @Mapping(target = "createdAt", ignore = true)
+  @Mapping(target = "programCancers", ignore = true)
+  @Mapping(target = "programPrimarySites", ignore = true)
+  @Mapping(target = "programInstitutions", ignore = true)
+  @Mapping(target = "programCountries", ignore = true)
+  @Mapping(target = "active", constant = "true")
+  @Mapping(target = "legacyShortName", ignore = true)
+  @Mapping(target = "dataCenterId", expression = "java(mapStringToUUID(p.getDataCenter().getId()))", ignore = false)
+  ProgramEntity programsDTOToProgramEntity(ProgramsDTO p);
+
+  default UUID mapStringToUUID (String id){
+    return UUID.fromString(id);
+  }
 
   @Mapping(target = "id", ignore = true)
   @Mapping(target = "updatedAt", ignore = true)

--- a/src/main/java/org/icgc/argo/program_service/converter/ProgramConverter.java
+++ b/src/main/java/org/icgc/argo/program_service/converter/ProgramConverter.java
@@ -63,6 +63,7 @@ public interface ProgramConverter {
   @Mapping(target = "programPrimarySites", ignore = true)
   @Mapping(target = "programInstitutions", ignore = true)
   @Mapping(target = "programCountries", ignore = true)
+  @Mapping(target = "dataCenterId", ignore = true)
   void updateProgram(ProgramEntity updatingProgram, @MappingTarget ProgramEntity programToUpdate);
 
   @Mapping(target = "clearField", ignore = true)

--- a/src/main/java/org/icgc/argo/program_service/properties/AppProperties.java
+++ b/src/main/java/org/icgc/argo/program_service/properties/AppProperties.java
@@ -121,6 +121,7 @@ public class AppProperties {
   }
 
   @Bean
+  @Profile("!test")
   public RSAPublicKey egoPublicKey(EgoClient egoClient) {
     return egoClient.getPublicKey();
   }

--- a/src/main/java/org/icgc/argo/program_service/services/ProgramService.java
+++ b/src/main/java/org/icgc/argo/program_service/services/ProgramService.java
@@ -40,11 +40,14 @@ import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import javax.validation.ValidatorFactory;
+import javax.validation.constraints.NotNull;
+
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.icgc.argo.program_service.converter.DataCenterConverter;
 import org.icgc.argo.program_service.converter.ProgramConverter;
+import org.icgc.argo.program_service.model.dto.DataCenterDetailsDTO;
 import org.icgc.argo.program_service.model.dto.DataCenterRequestDTO;
 import org.icgc.argo.program_service.model.entity.*;
 import org.icgc.argo.program_service.model.exceptions.BadRequestException;
@@ -283,6 +286,7 @@ public class ProgramService {
   public ProgramEntity updateProgram(
       @NonNull ProgramEntity programToUpdate,
       @NonNull ProgramEntity updatingProgram,
+      @NotNull DataCenterDetailsDTO dataCenterDetailsDTO,
       @NonNull List<String> cancers,
       @NonNull List<String> primarySites,
       @NonNull List<String> institutions,
@@ -296,6 +300,15 @@ public class ProgramService {
           .augmentDescription(
               "Cannot update program. Cancer, primary site, institution, country cannot be empty.")
           .asRuntimeException();
+    }
+
+    if (dataCenterDetailsDTO != null && !dataCenterDetailsDTO.getId().isEmpty()) {
+      val dataCenterEntity = dataCenterRepository.findById(UUID.fromString(dataCenterDetailsDTO.getId()));
+      if (dataCenterEntity.isEmpty()) {
+        throw new RecordNotFoundException("DataCenterId '" + dataCenterDetailsDTO.getId() + "' not found");
+      }
+      programToUpdate.setDataCenterId(UUID.fromString(dataCenterDetailsDTO.getId()));
+      processDataCenter(dataCenterDetailsDTO, dataCenterEntity.get());
     }
 
     // update associations
@@ -489,6 +502,15 @@ public class ProgramService {
     dataCenterConverter.updateDataCenter(updatingDataCenter, dataCenterToUpdate);
     dataCenterRepository.save(dataCenterToUpdate);
     return dataCenterToUpdate;
+  }
+
+  public void processDataCenter (
+          @NonNull DataCenterDetailsDTO dataCenterDetailsDTO, @NotNull DataCenterEntity updatingDataCenter) {
+    updatingDataCenter.setShortName(dataCenterDetailsDTO.getShortName());
+    updatingDataCenter.setName(dataCenterDetailsDTO.getName());
+    updatingDataCenter.setUiUrl(dataCenterDetailsDTO.getUiUrl());
+    updatingDataCenter.setGatewayUrl(dataCenterDetailsDTO.getGatewayUrl());
+    dataCenterRepository.save(updatingDataCenter);
   }
 
   public DataCenterEntity findDataCenterByShortName(@NonNull String name) {

--- a/src/main/java/org/icgc/argo/program_service/services/ProgramServiceFacade.java
+++ b/src/main/java/org/icgc/argo/program_service/services/ProgramServiceFacade.java
@@ -173,10 +173,31 @@ public class ProgramServiceFacade {
         programService.updateProgram(
             programToUpdate,
             updatingProgram,
+            null,
             program.getCancerTypesList(),
             program.getPrimarySitesList(),
             program.getInstitutionsList(),
             program.getCountriesList());
+    return programConverter.programEntityToUpdateProgramResponse(updatedProgram);
+  }
+
+  @Transactional
+  public UpdateProgramResponse updateProgramWithDataCenter (UpdateProgramRequest request, DataCenterDetailsDTO dataCenterDetailsDTO) {
+    val program = request.getProgram();
+    val updatingProgram = programConverter.programToProgramEntity(program);
+    val programToUpdate = programService.getProgram(updatingProgram.getShortName(), false);
+
+    updateMembershipPermission(programToUpdate, updatingProgram);
+
+    val updatedProgram =
+            programService.updateProgram(
+                    programToUpdate,
+                    updatingProgram,
+                    dataCenterDetailsDTO,
+                    program.getCancerTypesList(),
+                    program.getPrimarySitesList(),
+                    program.getInstitutionsList(),
+                    program.getCountriesList());
     return programConverter.programEntityToUpdateProgramResponse(updatedProgram);
   }
 

--- a/src/main/java/org/icgc/argo/program_service/services/ProgramServiceFacade.java
+++ b/src/main/java/org/icgc/argo/program_service/services/ProgramServiceFacade.java
@@ -173,7 +173,6 @@ public class ProgramServiceFacade {
         programService.updateProgram(
             programToUpdate,
             updatingProgram,
-            null,
             program.getCancerTypesList(),
             program.getPrimarySitesList(),
             program.getInstitutionsList(),

--- a/src/main/java/org/icgc/argo/program_service/services/ProgramServiceFacade.java
+++ b/src/main/java/org/icgc/argo/program_service/services/ProgramServiceFacade.java
@@ -182,7 +182,7 @@ public class ProgramServiceFacade {
   }
 
   @Transactional
-  public UpdateProgramResponse updateProgramWithDataCenter (UpdateProgramRequestDTO request)  {
+  public UpdateProgramResponse updateProgramWithDataCenter (UpdateProgramRequestDTO request) {
     val updatingProgram = programConverter.programsDTOToProgramEntity(request.getProgram());
     val programToUpdate = programService.getProgram(request.getProgram().getShortName(), false);
 

--- a/src/main/java/org/icgc/argo/program_service/services/ProgramServiceFacade.java
+++ b/src/main/java/org/icgc/argo/program_service/services/ProgramServiceFacade.java
@@ -182,10 +182,9 @@ public class ProgramServiceFacade {
   }
 
   @Transactional
-  public UpdateProgramResponse updateProgramWithDataCenter (UpdateProgramRequest request, DataCenterDetailsDTO dataCenterDetailsDTO) {
-    val program = request.getProgram();
-    val updatingProgram = programConverter.programToProgramEntity(program);
-    val programToUpdate = programService.getProgram(updatingProgram.getShortName(), false);
+  public UpdateProgramResponse updateProgramWithDataCenter (UpdateProgramRequestDTO request)  {
+    val updatingProgram = programConverter.programsDTOToProgramEntity(request.getProgram());
+    val programToUpdate = programService.getProgram(request.getProgram().getShortName(), false);
 
     updateMembershipPermission(programToUpdate, updatingProgram);
 
@@ -193,11 +192,11 @@ public class ProgramServiceFacade {
             programService.updateProgram(
                     programToUpdate,
                     updatingProgram,
-                    dataCenterDetailsDTO,
-                    program.getCancerTypesList(),
-                    program.getPrimarySitesList(),
-                    program.getInstitutionsList(),
-                    program.getCountriesList());
+                    request.getProgram().getDataCenter(),
+                    request.getProgram().getCancerTypes(),
+                    request.getProgram().getPrimarySites(),
+                    request.getProgram().getInstitutions(),
+                    request.getProgram().getCountries());
     return programConverter.programEntityToUpdateProgramResponse(updatedProgram);
   }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -88,11 +88,11 @@ spring.mail:
   host: localhost
   port: 10300
 
-spring.datasource:
-  driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
-  url: jdbc:tc:postgresql:9.5.13://localhost:5432/program_db?TC_INITFUNCTION=org.icgc.argo.program_service.test.FlywayInit::initTestContainers
-  username: postgres
-  password:
+#spring.datasource:
+#  driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+#  url: jdbc:tc:postgresql:9.5.13://localhost:5432/program_db?TC_INITFUNCTION=org.icgc.argo.program_service.test.FlywayInit::initTestContainers
+#  username: postgres
+#  password:
 
 app:
   grpcPort: 50052

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
     username: postgres
     password: password
   mail:
-    host: mailhog.qa.argo.cancercollaboratory.org
+    host: mailhog.argo-qa.cumulus.genomeinformatics.org
     port: 40001
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
@@ -32,7 +32,7 @@ retry:
     multiplier: 2.0
 
 app:
-  egoUrl: "https://ego.qa.argo.cancercollaboratory.org/api"
+  egoUrl: https://ego.argo-qa.cumulus.genomeinformatics.org/api
   egoClientId: "program-service"
   egoClientSecret: "qa-program-service"
   grpcEnabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
     username: postgres
     password: password
   mail:
-    host: mailhog.argo-qa.cumulus.genomeinformatics.org
+    host: mailhog.qa.argo.cancercollaboratory.org
     port: 40001
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
@@ -32,7 +32,7 @@ retry:
     multiplier: 2.0
 
 app:
-  egoUrl: "https://ego.argo-qa.cumulus.genomeinformatics.org/api"
+  egoUrl: "https://ego.qa.argo.cancercollaboratory.org/api"
   egoClientId: "program-service"
   egoClientSecret: "qa-program-service"
   grpcEnabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
     username: postgres
     password: password
   mail:
-    host: mailhog.qa.argo.cancercollaboratory.org
+    host: mailhog.argo-qa.cumulus.genomeinformatics.org
     port: 40001
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
@@ -32,7 +32,7 @@ retry:
     multiplier: 2.0
 
 app:
-  egoUrl: "https://ego.qa.argo.cancercollaboratory.org/api"
+  egoUrl: "https://ego.argo-qa.cumulus.genomeinformatics.org/api"
   egoClientId: "program-service"
   egoClientSecret: "qa-program-service"
   grpcEnabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -88,12 +88,6 @@ spring.mail:
   host: localhost
   port: 10300
 
-#spring.datasource:
-#  driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
-#  url: jdbc:tc:postgresql:9.5.13://localhost:5432/program_db?TC_INITFUNCTION=org.icgc.argo.program_service.test.FlywayInit::initTestContainers
-#  username: postgres
-#  password:
-
 app:
   grpcPort: 50052
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
     username: postgres
     password: password
   mail:
-    host: mailhog.argo-qa.cumulus.genomeinformatics.org
+    host: mailhog.qa.argo.cancercollaboratory.org
     port: 40001
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
@@ -32,7 +32,7 @@ retry:
     multiplier: 2.0
 
 app:
-  egoUrl: https://ego.argo-qa.cumulus.genomeinformatics.org/api
+  egoUrl: "https://ego.qa.argo.cancercollaboratory.org/api"
   egoClientId: "program-service"
   egoClientSecret: "qa-program-service"
   grpcEnabled: true

--- a/src/test/java/org/icgc/argo/program_service/grpc/ProgramServiceImplTest.java
+++ b/src/test/java/org/icgc/argo/program_service/grpc/ProgramServiceImplTest.java
@@ -20,8 +20,6 @@
 
 package org.icgc.argo.program_service.grpc;
 
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
-import static java.lang.String.format;
 import static org.apache.commons.lang.math.RandomUtils.nextInt;
 import static org.icgc.argo.program_service.proto.MembershipType.ASSOCIATE;
 import static org.icgc.argo.program_service.proto.MembershipType.FULL;
@@ -30,14 +28,11 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.*;
 
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.google.protobuf.BoolValue;
 import com.google.protobuf.StringValue;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
-
-import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.*;
 import javax.validation.constraints.Email;
@@ -49,36 +44,26 @@ import org.icgc.argo.program_service.converter.Grpc2JsonConverter;
 import org.icgc.argo.program_service.converter.ProgramConverter;
 import org.icgc.argo.program_service.model.entity.JoinProgramInviteEntity;
 import org.icgc.argo.program_service.model.entity.ProgramEntity;
-import org.icgc.argo.program_service.properties.AppProperties;
 import org.icgc.argo.program_service.proto.*;
-import org.icgc.argo.program_service.repositories.JoinProgramInviteRepository;
 import org.icgc.argo.program_service.services.InvitationService;
 import org.icgc.argo.program_service.services.ProgramService;
 import org.icgc.argo.program_service.services.ProgramServiceFacade;
 import org.icgc.argo.program_service.services.ValidationService;
 import org.icgc.argo.program_service.services.auth.AuthorizationService;
-import org.icgc.argo.program_service.services.ego.EgoRESTClient;
 import org.icgc.argo.program_service.services.ego.EgoService;
 import org.icgc.argo.program_service.services.ego.model.entity.EgoGroup;
 import org.icgc.argo.program_service.services.ego.model.entity.EgoPolicy;
 import org.icgc.argo.program_service.utils.EntityGenerator;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.dao.EmptyResultDataAccessException;
-import org.springframework.retry.support.RetryTemplate;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.util.DefaultUriBuilderFactory;
 import org.testcontainers.shaded.org.apache.commons.lang.RandomStringUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -95,34 +80,6 @@ class ProgramServiceImplTest {
   Grpc2JsonConverter grpc2JsonConvertor = mock(Grpc2JsonConverter.class);
   AuthorizationService authorizationService = mock(AuthorizationService.class);
   ValidationService validationService = mock(ValidationService.class);
-
-  private EgoRESTClient client;
-
-  @Autowired private RetryTemplate lenientRetryTemplate;
-
-  @Autowired private RetryTemplate retryTemplate;
-
-  @Autowired ProgramConverter converter;
-
-  @Autowired
-  JoinProgramInviteRepository inviteRepository;
-
-  @Autowired
-  AppProperties appProperties;
-
-  @Rule
-  public WireMockRule wireMockRule = new WireMockRule(options().dynamicPort());
-
-  @Rule public ExpectedException exceptionRule = ExpectedException.none();
-
-  private static final String TEST_EMAIL = "test_user@example.com";
-  private static final UUID TEST_ID = UUID.fromString("f0cfd733-3f41-46a7-b400-c1774dac4b21");
-  private static final UUID ADMIN_GROUP_ID =
-          UUID.fromString("09d93820-500e-4027-95ec-fdb5ce6986ce");
-  private static final UUID SUBMITTER_GROUP_ID =
-          UUID.fromString("64541e68-c6c6-469d-9dcf-9aa260ef17ea");
-  private static final String SHORT_NAME = "TEST-CA";
-  private static final String BASE_PATH = "src/test/resources/__files/";
   ProgramServiceFacade facade =
       new ProgramServiceFacade(
           programService,
@@ -140,25 +97,6 @@ class ProgramServiceImplTest {
 
   private static final String FULL_MEMBERSHIP_POLICY = "PROGRAMMEMBERSHIP-FULL";
   private static final String ASSOCIATE_MEMBERSHIP_POLICY = "PROGRAMMEMBERSHIP-ASSOCIATE";
-
-  @Before
-  public void setUp() {
-    val egoUrl = format("http://localhost:%s", wireMockRule.port());
-    val egoClientId = "program-service";
-    val egoClientSecret = "qa-program-service";
-
-    val testTemplate =
-            new RestTemplateBuilder()
-                    .basicAuthentication(egoClientId, egoClientSecret)
-                    .setConnectTimeout(Duration.ofSeconds(15))
-                    .build();
-    testTemplate.setUriTemplateHandler(new DefaultUriBuilderFactory(egoUrl));
-
-    client =
-            new EgoRESTClient(
-                    lenientRetryTemplate, retryTemplate, testTemplate, CommonConverter.INSTANCE);
-    egoService = new EgoService(converter, client, inviteRepository, appProperties);
-  }
 
   @Test
   void test_update_full_program_to_associate() {

--- a/src/test/java/org/icgc/argo/program_service/grpc/ProgramServiceImplTest.java
+++ b/src/test/java/org/icgc/argo/program_service/grpc/ProgramServiceImplTest.java
@@ -62,6 +62,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
 import org.testcontainers.shaded.org.apache.commons.lang.RandomStringUtils;
@@ -70,6 +71,7 @@ import org.testcontainers.shaded.org.apache.commons.lang.RandomStringUtils;
 @Slf4j
 @SpringBootTest
 @RunWith(SpringRunner.class)
+@ActiveProfiles("test")
 @Transactional
 class ProgramServiceImplTest {
   ProgramConverter programConverter = ProgramConverter.INSTANCE;


### PR DESCRIPTION

<img width="1076" alt="Screenshot 2024-03-01 at 11 37 52 AM" src="https://github.com/icgc-argo/program-service/assets/121898125/254c984c-7f47-4edf-a98a-e3e4dc5b2b28">
<img width="1061" alt="Screenshot 2024-03-01 at 11 38 00 AM" src="https://github.com/icgc-argo/program-service/assets/121898125/302c7a94-cc8f-4e50-a251-16f795b02d4d">
<img width="1069" alt="Screenshot 2024-03-01 at 11 38 14 AM" src="https://github.com/icgc-argo/program-service/assets/121898125/a6378f8f-13b6-477c-89d3-18dbad2ebb40">
As there was issue in the return response of UpdateProgramApi, we found out that the mapping between proto generated files and REST pojo's are failing on MembershipType enum. In order to fix this we have written custom mapping and used that for transformation between the two.

As shown in screenshots, we have tested the UpdateProgramApi in local by changes its fields which returns the response as expected and those changes are reflected in getProgramApi. 