### PR TITLE
Committing changes related to data center id null and empty check fix

### DIFF
--- a/src/main/java/org/icgc/argo/program_service/services/ProgramServiceFacade.java
+++ b/src/main/java/org/icgc/argo/program_service/services/ProgramServiceFacade.java
@@ -116,6 +116,9 @@ public class ProgramServiceFacade {
   @Transactional
   public CreateProgramResponse createProgram(CreateProgramRequest request, UUID dataCenterId) {
     val errors = validationService.validateCreateProgramRequest(request);
+    if (dataCenterId == null || dataCenterId.toString().isEmpty()) {
+      throw new BadRequestException("Data Center Id cannot be null or empty");
+    }
     if (errors.size() != 0) {
       throw Status.INVALID_ARGUMENT
           .augmentDescription(


### PR DESCRIPTION
As suggested by @justincorrigible , we have added an error handling when a user is trying to create a program without passing the datacenterid or passing it as null which is considered as an incorrect payload. Therefore, now the response will be returning as `400: Error: response status is 400` instead of 200. Also with a error message as **"Data Center Id cannot be null or empty"**