### PR TITLE
Skip Fetching Users for DEFAULT Role in EgoService

### DIFF
--- a/src/main/java/org/icgc/argo/program_service/services/ego/EgoService.java
+++ b/src/main/java/org/icgc/argo/program_service/services/ego/EgoService.java
@@ -225,7 +225,6 @@ public class EgoService {
 
   public EgoGroup getProgramEgoGroup(String programShortName, UserRole role) {
     if (UserRole.DEFAULT.equals(role)) {
-    // Log a message and return null or throw an exception to skip the DEFAULT role
     log.info("Skipping DEFAULT role for program {}", programShortName);
     throw new NotFoundException(format("Ego group for DEFAULT role in program '%s' should not be fetched.", programShortName));
   }
@@ -280,7 +279,7 @@ public class EgoService {
     for (val role : roles()) {
       if (UserRole.DEFAULT.equals(role)) {
         log.info("Skipping users fetch for DEFAULT role in program {}", programShortName);
-        continue; // Skip the DEFAULT role
+        continue;
       }
       EgoGroup group;
       try {

--- a/src/main/java/org/icgc/argo/program_service/services/ego/EgoService.java
+++ b/src/main/java/org/icgc/argo/program_service/services/ego/EgoService.java
@@ -224,6 +224,11 @@ public class EgoService {
   }
 
   public EgoGroup getProgramEgoGroup(String programShortName, UserRole role) {
+    if (UserRole.DEFAULT.equals(role)) {
+    // Log a message and return null or throw an exception to skip the DEFAULT role
+    log.info("Skipping DEFAULT role for program {}", programShortName);
+    throw new NotFoundException(format("Ego group for DEFAULT role in program '%s' should not be fetched.", programShortName));
+  }
     val name = groupName(programShortName, role);
     val g = egoClient.getGroupByName(name);
     return g.orElseThrow(
@@ -273,6 +278,10 @@ public class EgoService {
   public List<User> getUsersInProgram(String programShortName) {
     val userResults = new ArrayList<User>();
     for (val role : roles()) {
+      if (UserRole.DEFAULT.equals(role)) {
+        log.info("Skipping users fetch for DEFAULT role in program {}", programShortName);
+        continue; // Skip the DEFAULT role
+      }
       EgoGroup group;
       try {
         group = getProgramEgoGroup(programShortName, role);


### PR DESCRIPTION
**Summary**
This PR addresses the issue of unnecessary attempts to fetch users for the DEFAULT role in the EgoService, which was causing errors in the logs.

**Changes**

- [x] Updated `getProgramEgoGroup` method to skip the DEFAULT role.
- [x] Updated `getUsersInProgram` method to skip fetching users for the DEFAULT role.

**Details**
**1. **getProgramEgoGroup Method**:**
   - Added a condition to skip the DEFAULT role and log an appropriate message.
   - Throws a NotFoundException if the DEFAULT role is encountered.

**2. **getUsersInProgram Method**:**
   - Added a condition to continue the loop if the DEFAULT role is encountered.
   - Logs an informational message when skipping the DEFAULT role.
