### PR TITLE
Move joinProgramInvite to PublicPorgramController

### DIFF
--- a/src/main/java/org/icgc/argo/program_service/controller/ProgramController.java
+++ b/src/main/java/org/icgc/argo/program_service/controller/ProgramController.java
@@ -3,6 +3,9 @@ package org.icgc.argo.program_service.controller;
 import com.google.protobuf.StringValue;
 import io.grpc.StatusRuntimeException;
 import io.swagger.v3.oas.annotations.Parameter;
+import java.io.IOException;
+import java.util.List;
+import java.util.NoSuchElementException;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apache.commons.lang.exception.ExceptionUtils;
@@ -19,10 +22,7 @@ import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import java.io.IOException;
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.UUID;
+
 
 @Slf4j
 @RestController
@@ -225,20 +225,6 @@ public class ProgramController {
       log.error("Exception throw in joinProgram: {}", e.getMessage());
       throw new NotFoundException("User not found");
     }
-  }
-
-  @GetMapping(value = "/joinProgramInvite/{invite_id}")
-  public ResponseEntity<GetJoinProgramInviteResponseDTO> getJoinProgramInvite(
-      @Parameter(hidden = true) @RequestHeader(value = "Authorization", required = false)
-          final String authorization,
-      @PathVariable(value = "invite_id", required = true) String inviteId) {
-    val invitation = serviceFacade.getInvitationById(UUID.fromString(inviteId));
-    GetJoinProgramInviteResponseDTO getJoinProgramInviteResponseDTO =
-        new GetJoinProgramInviteResponseDTO();
-    getJoinProgramInviteResponseDTO.setInvitation(
-        grpc2JsonConverter.prepareGetJoinProgramInviteResponse(invitation));
-    return new ResponseEntity<GetJoinProgramInviteResponseDTO>(
-        getJoinProgramInviteResponseDTO, HttpStatus.OK);
   }
 
   @GetMapping(value = "/cancers")

--- a/src/main/java/org/icgc/argo/program_service/controller/PublicProgramController.java
+++ b/src/main/java/org/icgc/argo/program_service/controller/PublicProgramController.java
@@ -1,25 +1,34 @@
 package org.icgc.argo.program_service.controller;
 
 import java.util.List;
+import java.util.UUID;
+
+import lombok.val;
 import org.icgc.argo.program_service.model.dto.ProgramDTO;
+import org.icgc.argo.program_service.model.dto.GetJoinProgramInviteResponseDTO;
 import org.icgc.argo.program_service.model.dto.builder.ProgramDTOBuilder;
 import org.icgc.argo.program_service.model.entity.ProgramEntity;
 import org.icgc.argo.program_service.services.ProgramService;
+import org.icgc.argo.program_service.services.ProgramServiceFacade;
+import org.icgc.argo.program_service.converter.Grpc2JsonConverter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/public")
+@RequestMapping("/public/programs")
 public class PublicProgramController {
 
   @Autowired ProgramService programService;
 
   @Autowired ProgramDTOBuilder programDTOBuilder;
+  @Autowired private ProgramServiceFacade serviceFacade;
+  @Autowired private Grpc2JsonConverter grpc2JsonConverter;
 
   @GetMapping(value = "/program")
   public ResponseEntity<Object> getPublicProgramData(@RequestParam(required = true) String name) {
@@ -43,5 +52,17 @@ public class PublicProgramController {
   public ResponseEntity<Object> getRegisteredProgramData() {
     List<String> programNames = programService.getAllProgramNames();
     return ResponseEntity.ok(programNames);
+  }
+
+  @GetMapping(value = "/joinProgramInvite/{invite_id}")
+  public ResponseEntity<GetJoinProgramInviteResponseDTO> getJoinProgramInvite(
+          @PathVariable(value = "invite_id", required = true) String inviteId) {
+    val invitation = serviceFacade.getInvitationById(UUID.fromString(inviteId));
+    GetJoinProgramInviteResponseDTO getJoinProgramInviteResponseDTO =
+            new GetJoinProgramInviteResponseDTO();
+    getJoinProgramInviteResponseDTO.setInvitation(
+            grpc2JsonConverter.prepareGetJoinProgramInviteResponse(invitation));
+    return new ResponseEntity<GetJoinProgramInviteResponseDTO>(
+            getJoinProgramInviteResponseDTO, HttpStatus.OK);
   }
 }


### PR DESCRIPTION
### Summary:
This PR addresses an issue where the `GET /programs/joinProgramInvite` endpoint was incorrectly set to require authorization. To allow users who are not logged in to access this endpoint, the following changes have been made:

- [x] Moved Endpoint to PublicProgramController:

The method handling the `GET /programs/joinProgramInvite` request has been moved from `ProgramController` to `PublicProgramController` to ensure it is publicly accessible.

- [x] Removed Authorization Requirement:

All security annotations (e.g., `@PreAuthorize`) have been removed from the `joinProgramInvite` method to make it accessible without requiring the user to be logged in.
### Testing:
The endpoint has been tested to ensure it can be accessed without authentication.
Verified that the existing functionality of the endpoint remains unchanged after the move.
### Impact:
This change allows users who are not logged in to confirm their invite information without encountering authorization errors.